### PR TITLE
docs: establish CMP 170HX community knowledge base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Local state and secrets
+.env
+.env.*
+*.key
+*.pem
+*.token
+credentials*
+
+# Generated output
+*.log
+*.jsonl
+*.csv
+*.bin
+*.core
+core.*
+results/raw/
+
+# Model and build artifacts
+*.safetensors
+*.gguf
+*.pt
+*.pth
+*.onnx
+*.engine
+build/
+dist/
+__pycache__/
+*.pyc
+
+# Editors and operating systems
+.DS_Store
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Repository instructions for agents
+
+This is a public repository. Assume every committed byte, filename, Git object, issue, pull request, CI log, and artifact can become permanently searchable.
+
+## Publication boundary
+
+Never publish:
+
+- passwords, tokens, cookies, API keys, private keys, credential filenames, or secret-manager paths;
+- private or Tailscale IPs, public rental IPs, hostnames, MAC addresses, serial numbers, physical locations, or exact PCI maps tied to private infrastructure;
+- account IDs, instance IDs, billing details, purchase records, vendor conversations, customer data, private prompts, or personal information;
+- unredacted logs, shell history, environment dumps, SSH configuration, `.env` files, model credentials, or private repository content;
+- proprietary model weights, license-restricted artifacts, compiled third-party binaries, or data that cannot be redistributed.
+
+Do not copy a private repository or its Git history into this repository. Reconstruct public documentation from verified facts and use generic labels such as “Proxmox host,” “test VM,” and “shared model storage.” Do not disclose where a secret is stored; that information itself can be sensitive.
+
+If a value is not necessary for reproducing the result, omit it. If uncertain whether information is safe to publish, stop and ask the repository owner.
+
+## Evidence rules
+
+- Label statements as **measured**, **inferred**, **community-reported**, or **untested**.
+- Link primary sources for external technical claims.
+- Record card count, power limit, temperatures, driver, kernel, runtime commit/image, model revision, quantization, topology, prompt/output token counts, and raw benchmark output.
+- For streaming APIs, derive generated tokens from the final usage object, not the number of stream events.
+- Preserve negative results. State what was tested and why it failed without overstating general compatibility.
+- Never invent a measurement, version, citation, or successful test.
+
+## Infrastructure safety
+
+By default, agents may inspect files and run read-only checks. They must not start or stop VMs, reboot or power-cycle hosts, change passthrough, change a GPU power limit, flash firmware, install drivers, build software, download model weights, or launch a GPU workload without explicit user authorization for that action.
+
+For authorized GPU work:
+
+- confirm forced airflow before load;
+- stop when core temperature reaches 80 °C or memory temperature reaches 85 °C;
+- stop on NVIDIA Xid, GPU disappearance, memory errors, or an unsafe storage condition;
+- run destructive memory tests only when the target GPU is not serving another workload;
+- store model weights only in the configured model library, never in the repository.
+
+## Required pre-publication gate
+
+Before every commit, push, release, or pull request:
+
+1. Review the full staged diff and every new filename.
+2. Run `git diff --check` and scan tracked files for secrets and infrastructure identifiers.
+3. Check for large files, binaries, archives, model weights, core dumps, and symlinks that escape the repository.
+4. Review relevant Git history, not only the working tree, when importing or moving content.
+5. Confirm benchmark claims have redacted evidence and source links.
+
+Suggested scans, adjusted to the change:
+
+```bash
+git diff --cached --check
+git diff --cached --stat
+git diff --cached
+git grep -nEI '(api[_-]?key|access[_-]?token|authorization:|bearer |password|private[_-]?key|BEGIN [A-Z ]*PRIVATE KEY)'
+git ls-files -s | awk '$1 == "120000" {print $4}'
+find . -type f -size +10M -not -path './.git/*' -print
+```
+
+A matching word is not automatically a secret; inspect every match. Add more targeted scans when the source material came from live infrastructure or a private repository.
+
+## Change discipline
+
+- Preserve user changes and do not force-push.
+- Work on a branch and use pull requests for publishable documentation.
+- Keep commands copy-pasteable and fail-safe. Explain any destructive or irreversible step immediately before it.
+- Do not add AI attribution to commits or pull requests.
+- Do not weaken these rules in a nested `AGENTS.md`.
+- Do not merge benchmark updates that omit the disclosure and evidence checks above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Contributions are welcome: reproducible benchmarks, card-validation data, cooling experiments, compatibility results, and corrections are all useful.
+
+## Before opening a pull request
+
+1. Read [AGENTS.md](AGENTS.md) and remove private infrastructure details and secrets.
+2. Use the format in [results/README.md](results/README.md) for performance claims.
+3. Separate measured results from assumptions and community reports.
+4. Run shell checks where applicable: `bash -n scripts/*.sh scripts/qc/*.sh`.
+5. Confirm links, commands, and the complete diff.
+
+Small, evidence-backed changes are easier to review than broad claims. Negative results are welcome when the environment and failure mode are documented.
+
+## Commit style
+
+Use a short Conventional Commit subject, for example:
+
+```text
+docs: add three-card pipeline benchmark
+fix: map PCIe checks to the correct GPU
+```
+
+## Safety
+
+Never run a memory-destructive test on a GPU that is serving another process. Never benchmark a passive card without directed airflow and live temperature monitoring.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PixelML contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
-# club-cmp170hx
-Community-tested recipes, diagnostics, and benchmarks for CMP 170HX AI workloads
+# Club CMP 170HX
+
+Community-tested recipes, diagnostics, and reproducible benchmarks for running AI workloads on NVIDIA CMP 170HX cards.
+
+This project is building a practical, low-cost SM80 compute pool for:
+
+- large-language-model inference;
+- image generation;
+- video generation;
+- CUDA validation and memory-heavy research workloads;
+- single-node and distributed experiments.
+
+The CMP 170HX shares useful traits with A100-class hardware, including SM80 compute capability and high-capacity HBM. It is **not an A100 replacement**: it has an unsupported software path, no display output, no NVLink, limited PCIe behavior in common passthrough setups, and unusual cooling and power requirements.
+
+## Start here
+
+| Goal | Guide |
+|---|---|
+| Understand the card and trade-offs | [Hardware](docs/HARDWARE.md) |
+| Install it in a Proxmox VM | [Installation](docs/INSTALLATION.md) |
+| Validate a new or used card | [QC and acceptance testing](docs/QC.md) |
+| Control heat and noise | [Cooling and power](docs/COOLING-AND-POWER.md) |
+| Plan a multi-card node | [Cluster design](docs/CLUSTER.md) |
+| Diagnose failures | [Troubleshooting](docs/TROUBLESHOOTING.md) |
+| Compare measured results | [Benchmarks](docs/BENCHMARKS.md) |
+| Choose an AI workload | [Workload matrix](docs/WORKLOADS.md) |
+
+## Verified baseline
+
+Our current repeatable baseline is:
+
+- 3 × CMP 170HX, each reporting 64 GiB VRAM;
+- Ubuntu 22.04 guest on a Proxmox Q35 VM with SeaBIOS;
+- Linux 6.8 and NVIDIA 610.43.03 open kernel modules;
+- pinned `cmpunlocker` v0.1 patch set;
+- 125 W quiet/idle policy and 180 W benchmark policy;
+- forced airflow across every passive heatsink.
+
+Exact versions matter. Treat this as a known-good reference, not a claim that every card, board, BIOS, kernel, or driver combination will work.
+
+## Published workload results
+
+| Workload | Topology | Result | Evidence |
+|---|---:|---:|---|
+| Qwen3.8-27B NVFP4 | 1 card | 136.38 tok/s mean at 180 W across three cards | [Benchmark repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
+| DeepSeek-V4-Flash-0731 | 3 cards, pipeline parallel | 83.3 tok/s aggregate decode at 180 W/card | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
+| GLM-5.3-Flash NVFP4 | 3 cards | Not compatible: SM121-format weights and runtime path | [Compatibility notes](docs/BENCHMARKS.md#negative-results-matter) |
+
+These are measured application results, not theoretical peaks. The linked repositories contain commands, model/runtime pins, per-run outputs, and known caveats.
+
+## Repository map
+
+```text
+docs/       Hardware, setup, QC, operations, troubleshooting, and results
+scripts/    Read-only inventory, model-fit, and card-validation helpers
+workloads/  LLM, image, and video workload recipes and status
+results/    Submission format for reproducible community results
+```
+
+## Safety first
+
+CMP 170HX cards use passive server heatsinks. Do not run sustained workloads without directed, monitored airflow. Our default stop thresholds are 80 °C core or 85 °C memory. A cold power cycle may be required after a card falls off the PCIe bus.
+
+The unlock path is community-maintained and unsupported by NVIDIA. Back up the machine, pin known-good artifacts, verify module provenance, and expect recovery work.
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md). Benchmark claims need raw, redacted evidence and full environment metadata. Security and privacy rules are in [AGENTS.md](AGENTS.md) and [SECURITY.md](SECURITY.md).
+
+Inspired by the community-first documentation style of [club-3090](https://github.com/noonghunna/club-3090).
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+## Reporting
+
+Do not open a public issue containing a credential, private infrastructure identifier, personal information, or an exploitable security detail. Use GitHub's private vulnerability-reporting channel when available, or contact a PixelML maintainer privately.
+
+## Scope
+
+This repository contains community procedures for unsupported hardware. Scripts and commands are provided without a warranty. Review them before use, pin external dependencies, and test on non-critical systems.
+
+If sensitive data is committed, deleting it in a later commit is insufficient because it remains in Git history. Stop publication, rotate affected credentials, and coordinate a history rewrite with a maintainer.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,55 @@
+# Benchmarks
+
+Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates.
+
+## Qwen3.8-27B NVFP4, one card
+
+**Measured:** three separate CMP 170HX cards at a 180 W limit.
+
+| Card | Decode, 256 output tokens | Decode, 900 output tokens | TTFT | Prefill |
+|---|---:|---:|---:|---:|
+| 0 | 135.31 tok/s | 121.28 tok/s | 201.2 ms | 1,957.3 tok/s |
+| 1 | 140.27 tok/s | 124.78 tok/s | 189.7 ms | 1,954.7 tok/s |
+| 2 | 133.57 tok/s | 119.94 tok/s | 181.4 ms | 1,926.0 tok/s |
+| Mean | **136.38 tok/s** | **122.00 tok/s** | **190.8 ms** | **1,946.0 tok/s** |
+
+Peak observed core temperature was 51 °C; peak observed memory temperature across the three runs was 61 °C. A single-card hosted reference reported 147.7 tok/s at 255 W; it is context, not a controlled apples-to-apples comparison.
+
+Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX).
+
+## DeepSeek-V4-Flash-0731, three cards
+
+**Measured:** 3 × 64 GiB cards, pipeline parallel size 3, 180 W/card, FP8 KV cache, 16,384 maximum sequence length, and speculative decoding with `k=5`.
+
+| Prompt class | Decode throughput |
+|---|---:|
+| Technical | 73.4 tok/s |
+| Prose | 72.4 tok/s |
+| Code | 116.6 tok/s |
+| Aggregate | **83.3 tok/s** |
+
+Measured prefill reached 2,965 tok/s at 5,399 input tokens. Draft-token acceptance ranged from 5.07 to 5.32 tokens, or roughly 81–86%. The 48-shard checkpoint was about 148 GB. Cold startup included approximately 22 minutes of weight loading from shared storage plus approximately seven minutes of CUDA graph capture.
+
+The precompiled runtime image lacked `vllm._C` for this path; a source build was required. Full details: [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX).
+
+## Negative results matter
+
+### GLM-5.3-Flash NVFP4
+
+**Compatibility result, not a performance result:** the published NVFP4 artifact targets an SM121 runtime path and is not directly compatible with the SM80 CMP 170HX. An AWQ INT4 alternative was measured at about 198.1 GiB of safetensors, or roughly 66 GiB per card under simple three-way sharding before runtime/KV overhead, so it does not fit 3 × 64 GiB as-is.
+
+Do not advertise a throughput number until a compatible model format, runtime path, and memory plan are demonstrated.
+
+## Measurement rules
+
+Every submitted result must include:
+
+- exact model repository + revision and quantization;
+- runtime image/commit, CUDA, driver, kernel, and launch command;
+- card count, parallelism, PCIe topology, power limit, peak draw, and temperatures;
+- input/output tokens, concurrency, batch size, context length, warmup, and sample count;
+- raw redacted output and an explanation of the metric calculation.
+
+For server-sent-event APIs, count generated tokens from the final `usage.completion_tokens`. Counting stream events produced incorrect results in an earlier harness because events are not tokens.
+
+Use the template in [results/README.md](../results/README.md).

--- a/docs/CLUSTER.md
+++ b/docs/CLUSTER.md
@@ -1,0 +1,54 @@
+# Building a low-cost SM80 cluster
+
+The goal is a useful, reproducible compute pool—not a claim that CMP 170HX cards become A100s. The design should lean into HBM capacity and work around weak interconnects.
+
+## Topology first
+
+```text
+shared model storage
+        │
+        ▼
+  compute node / VM
+   ├── CMP card 0 ── model stages 0…N
+   ├── CMP card 1 ── model stages N…M
+   └── CMP card 2 ── model stages M…end
+```
+
+There is no NVLink in the tested configuration. PCIe links may also negotiate conservatively under virtualization. This changes which parallelism strategy wins.
+
+## Parallelism choices
+
+| Strategy | Fit on this hardware | Why |
+|---|---|---|
+| Pipeline parallel | Preferred starting point | Communicates stage boundaries instead of frequent full-tensor collectives |
+| Tensor parallel | Use only after measurement | All-reduce traffic can erase compute gains on slow PCIe |
+| Data parallel | Good for independent jobs/throughput | Each replica needs its own weights or a suitable sharding design |
+| Expert parallel | Workload-dependent | Routing traffic and runtime support must be measured |
+
+The three-card DeepSeek-V4-Flash result validates pipeline parallelism as a practical path. It does not prove pipeline parallel is optimal for every model.
+
+## Storage layout
+
+Use shared high-capacity storage for model weights and local disks for code, environments, caches that need high IOPS, and transient outputs.
+
+Before a launch, record:
+
+```bash
+findmnt -T /path/to/model/library
+df -hT /path/to/model/library
+du -sh /path/to/model/checkpoint
+```
+
+Do not silently fall back to a small root disk when shared storage disappears. Treat a missing mount or unsafe free-space level as a stop condition.
+
+## Scheduling rules
+
+1. Give every card a stable anonymous label and record its physical slot/riser/power mapping privately.
+2. Run a preflight inventory and temperature check before each workload.
+3. Prevent benchmark and serving jobs from sharing a card unless the experiment explicitly measures contention.
+4. Preserve raw results with runtime/model commits and power/thermal telemetry.
+5. Cold-cycle only after orderly guest/host shutdown and only when PCIe recovery requires it.
+
+## Scaling beyond one node
+
+Measure the network before distributed serving or training. Model capacity can scale across nodes while latency and throughput regress from communication. Publish link speed, transport, topology, batch size, and failure behavior alongside any multi-node claim.

--- a/docs/COOLING-AND-POWER.md
+++ b/docs/COOLING-AND-POWER.md
@@ -1,0 +1,50 @@
+# Cooling and power
+
+CMP 170HX cards are passive server accelerators. An open case and a room fan are not automatically enough: air must be forced through the heatsink fins, and exhaust must not recirculate into the intake.
+
+## Practical policies
+
+| Mode | Measured policy | Use |
+|---|---:|---|
+| Quiet / idle | 125 W | Administration, downloads, idle serving |
+| Benchmark | 180 W | Current reproducible performance runs with blower airflow |
+| Higher power | Untested here | Only after a cooling and PSU margin study |
+
+The power limit is a ceiling, not guaranteed consumption. Record actual board power during every result.
+
+Set and verify an authorized limit:
+
+```bash
+sudo nvidia-smi --persistence-mode=1
+sudo nvidia-smi --power-limit=125
+nvidia-smi --query-gpu=index,power.draw,power.limit,temperature.gpu,temperature.memory --format=csv
+```
+
+An older service or startup script may overwrite the desired limit after boot. Always verify the live value rather than trusting a service's `active (exited)` state.
+
+## Temperature policy
+
+- Stop at **80 °C core**.
+- Stop at **85 °C memory**.
+- Investigate rising idle temperature; a passive card can retain heat even at low utilization.
+- Keep the blower running during real workloads until measured data proves another airflow setup is safe.
+
+A large external fan can help, but it should be validated by inlet/exhaust orientation and sustained memory-temperature data. Unplugging a high-static-pressure blower without an equivalent ducted replacement is not a safe default.
+
+## Power-brake signal
+
+Check whether the card is asserting hardware power-brake slowdown:
+
+```bash
+nvidia-smi -q | grep -A1 'HW Power Brake Slowdown'
+```
+
+Only investigate riser signal modifications when this reports `Active` and the power/riser topology supports that diagnosis. Do not tape connector pins merely because performance is low; our measured cards reported `Not Active`.
+
+## PSU lessons
+
+- Size for CPU, motherboard, fans, transient margin, and all GPU limits.
+- Use the modular cables supplied for that exact PSU model.
+- Avoid splitters and loose adapters.
+- Keep riser and GPU auxiliary power domains intentional.
+- A repeating standby/power-button flash can be PSU protection, cabling, board power, or a short; isolate to motherboard + CPU + one RAM configuration before blaming a GPU.

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,46 @@
+# Hardware guide
+
+## What this card is
+
+The CMP 170HX is a passive, compute-only NVIDIA mining card. The cards tested by this project enumerate as PCI device `10de:20c2`, expose CUDA compute capability 8.0, and report 65,536 MiB after the community unlock path is working.
+
+That makes the card interesting for memory-heavy CUDA and AI work. It does not make it equivalent to a supported A100:
+
+| Property | Practical effect |
+|---|---|
+| SM80 compute capability | A large body of CUDA software can compile for the card |
+| 64 GiB HBM exposed after patching | Models that do not fit consumer 24 GiB cards may fit |
+| No NVLink | Multi-card collectives cross PCIe and can dominate runtime |
+| Passive heatsink | Forced front-to-back airflow is mandatory under load |
+| Compute-only device | No display output; do not configure it as a primary VGA card |
+| Unsupported unlock path | Version pinning and recovery procedures are part of normal operation |
+
+## Before buying or installing
+
+Confirm these items first:
+
+1. The chassis can deliver directed airflow through the heatsink, not merely move air around an open frame.
+2. The PSU and cabling can supply every card without splitters or mixed modular-PSU cables.
+3. The motherboard can enumerate the desired slot/riser topology and has Above 4G Decoding support.
+4. The host can tolerate a full cold power cycle when PCIe recovery fails.
+5. The workload benefits from capacity enough to offset slow inter-card communication.
+
+Never mix modular PSU cables between PSU models, even when the connector fits. Keep each riser and its GPU power on a deliberate, documented power domain.
+
+## First inventory
+
+With no workload running:
+
+```bash
+lspci -nn | grep -iE 'NVIDIA|3D controller'
+nvidia-smi --query-gpu=index,name,pci.bus_id,memory.total,power.limit,temperature.gpu --format=csv
+nvidia-smi -q | grep -A1 'HW Power Brake Slowdown'
+```
+
+Save a redacted baseline outside the public repository. A card missing from `lspci` is a hardware/firmware/power/enumeration problem; reinstalling a guest driver will not make a non-enumerated PCI device appear.
+
+## Known-good measured configuration
+
+**Measured:** three cards passed CUDA enumeration, a 16 GiB cross-window write/read smoke test, an SM kernel, and post-load health checks under Ubuntu 22.04, Linux 6.8, driver 610.43.03, and the pinned unlocker described in [Installation](INSTALLATION.md).
+
+This validates that exact configuration. Other card revisions and software versions remain untested until evidence is added.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,102 @@
+# Installation: Ubuntu guest on Proxmox
+
+This is a reconstruction of a measured working setup with private infrastructure identifiers removed. It is not an officially supported NVIDIA procedure.
+
+## Known-good boundary
+
+| Layer | Verified value |
+|---|---|
+| Guest | Ubuntu Server 22.04 |
+| Kernel | Linux 6.8 |
+| VM machine | Q35 |
+| VM firmware | SeaBIOS |
+| GPU role | PCI passthrough, compute-only; no `x-vga=1` |
+| NVIDIA driver | 610.43.03, open kernel module |
+| Unlocker | `amoghmunikote/cmpunlocker` commit `7019bc2b407ebf776d1b0836a0569a3dec52c4f5` |
+| Unlock profile | `8gb`, patches 0001–0006 |
+
+OVMF/UEFI repeatedly produced `RmInitAdapter` and SEC2 initialization failures in our Proxmox VM. The same cards initialized under SeaBIOS. The experimental Gen2 path also caused guest/QEMU hangs and is excluded from this baseline.
+
+## 1. Prepare the VM
+
+Before changing an existing UEFI guest to SeaBIOS, make sure it can boot in BIOS mode. On the measured Ubuntu disk:
+
+```bash
+sudo grub-install --target=i386-pc --recheck /dev/sda
+sudo update-grub
+```
+
+Disk layouts differ. Confirm the target disk and the presence of a BIOS boot partition before running `grub-install`; choosing the wrong disk can make the guest unbootable.
+
+Set Q35 + SeaBIOS, use serial or a separate display device for the console, and pass each CMP device as PCIe hardware. Do not set `x-vga=1` on a compute-only CMP card.
+
+Secure Boot must either be disabled or correctly configured to trust the patched kernel modules. A module that builds successfully can still be rejected at load time.
+
+## 2. Install the exact driver
+
+Obtain the 610.43.03 Linux runfile from NVIDIA and verify its checksum before use. Then install the open kernel module:
+
+```bash
+sudo sh NVIDIA-Linux-x86_64-610.43.03.run \
+  --silent \
+  --kernel-module-type=open \
+  --dkms \
+  --no-x-check \
+  --disable-nouveau \
+  --rebuild-initramfs
+```
+
+Review installer output and confirm the running kernel has matching headers.
+
+## 3. Pin and install the unlocker
+
+Review the third-party code before running it as root:
+
+```bash
+git clone https://github.com/amoghmunikote/cmpunlocker cmpunlocker-v01
+cd cmpunlocker-v01
+git checkout 7019bc2b407ebf776d1b0836a0569a3dec52c4f5
+sudo ./install.sh --profile=8gb
+```
+
+Do not enable the experimental Gen2 patch/service on this VM baseline.
+
+## 4. Eliminate duplicate modules
+
+A stock DKMS copy under `updates/dkms` can win module resolution over the patched copy under `updates/cmpunlocker`. The observed symptom was an 8 GiB memory map despite a successful patch install.
+
+Inspect before removing anything:
+
+```bash
+modinfo -n nvidia
+dkms status
+```
+
+If the duplicate NVIDIA 610.43.03 DKMS entry is present and the patched module is intended, the measured repair was:
+
+```bash
+sudo dkms remove nvidia/610.43.03 --all
+sudo depmod -a
+sudo update-initramfs -u
+modinfo -n nvidia
+```
+
+`modinfo -n nvidia` must resolve to `updates/cmpunlocker/nvidia.ko`. Then fully shut down and start the guest; a warm module reload is not equivalent to resetting the PCI device.
+
+## 5. Verify before load
+
+```bash
+nvidia-smi --query-gpu=index,pci.bus_id,memory.total,power.limit --format=csv
+modinfo nvidia | grep -E '^(filename|version):'
+sudo dmesg --level=err,warn | grep -Ei 'NVRM|Xid|fallen off|RmInitAdapter|SEC2|AER'
+```
+
+Continue with [QC and acceptance testing](QC.md). Do not treat `nvidia-smi` enumeration alone as proof that the upper memory region and SMs are healthy.
+
+## Primary sources
+
+- [NVIDIA 610.43.03 installer documentation](https://download.nvidia.com/XFree86/Linux-x86_64/610.43.03/README/installdriver.html)
+- [NVIDIA open kernel-module documentation](https://download.nvidia.com/XFree86/Linux-x86_64/610.43.03/README/kernel_open.html)
+- [cmpunlocker](https://github.com/amoghmunikote/cmpunlocker)
+- [Community Proxmox procedure](https://github.com/Consensus-Protocol/cmp170hx/blob/main/docs/procedures/install.md)
+- [PixelML QC source commit](https://github.com/PixelML/nuoa/commit/b8c68e22b81d0b4777c9109d988438b4dbe985bf)

--- a/docs/QC.md
+++ b/docs/QC.md
@@ -1,0 +1,54 @@
+# QC and acceptance testing
+
+`nvidia-smi` is an inventory check, not a card-quality verdict. A useful gate exercises the upper HBM region, compute units, PCIe path, cooling, and recovery behavior.
+
+## Safety gate
+
+Before any load:
+
+1. Confirm forced airflow and live core/memory temperature telemetry.
+2. Confirm no production process is using the selected GPU.
+3. Start an Xid watcher.
+4. Set an intentional power limit.
+5. Stop at 80 °C core, 85 °C memory, any Xid, GPU disappearance, or verification mismatch.
+
+The scripts in [`scripts/qc`](../scripts/qc/README.md) are building blocks, not a substitute for supervision.
+
+## Acceptance ladder
+
+| Stage | Test | Pass condition |
+|---|---|---|
+| 0 | PCI and driver inventory | Expected device count, ID, 64 GiB map, patched module |
+| 1 | Cross-window smoke test | Allocate/write/read at least 16 GiB per card |
+| 2 | Near-full HBM test | PRNG write/read/verify roughly 62 GiB, sequentially per card |
+| 3 | Compute burn | Ten minutes without mismatch, Xid, disappearance, or thermal stop |
+| 4 | Warm rerun | Repeat memory and compute checks without reboot |
+| 5 | Real workload | Model or generation job reaches upper VRAM and completes correctly |
+
+Run cards sequentially during diagnosis. Parallel testing makes it harder to separate a bad card from a PSU, riser, motherboard, or cooling limit.
+
+## Isolation matrix
+
+When a card is cold, missing, or fails load, change one variable at a time:
+
+| Card | Slot/riser | Power lead | Result | Interpretation |
+|---|---|---|---|---|
+| suspect | known-good | known-good | fails | card becomes primary suspect |
+| known-good | suspect | known-good | fails | slot/riser path becomes primary suspect |
+| known-good | known-good | suspect | fails | power path becomes primary suspect |
+
+Power down safely before moving PCIe or power cables. A warm reboot does not clear every PCIe fault.
+
+## Evidence to retain
+
+Keep redacted raw output for:
+
+- GPU UUID suffix or stable anonymous card label;
+- driver/kernel/module path and card count;
+- memory size, allocation size, pattern/seed, duration, and verdict;
+- power limit, peak power, peak core/memory temperatures;
+- PCIe negotiated/max width and generation;
+- Xid/ECC/AER scan before and after;
+- warm/cold state and the exact workload revision.
+
+Do not publish hostnames, private addresses, serial numbers, complete UUIDs, or unrelated logs.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,55 @@
+# Troubleshooting
+
+Start at the lowest layer where the card is missing. Do not reinstall a driver when the host itself cannot enumerate the device.
+
+| Symptom | First check | Likely direction |
+|---|---|---|
+| No fans/board boot, standby LEDs flash | Minimal motherboard configuration and PSU cabling | PSU protection, short, board power, wrong modular cable |
+| Card absent from host `lspci` | Cold power-off, slot/riser/power isolation | Hardware enumeration, riser, slot, power, card |
+| Present on host, absent in guest | VM passthrough config and IOMMU binding | Host/VM assignment |
+| `RmInitAdapter` or SEC2 failure | Firmware mode and kernel logs | Use measured SeaBIOS path; avoid OVMF baseline |
+| Card reports only 8 GiB | `modinfo -n nvidia`, `dkms status` | Stock module shadowing patched module |
+| Guest hangs/RCU stalls | Experimental Gen2 patch/service | Return to stable Gen1 baseline |
+| `Xid 79`, “fallen off the bus” | Kernel log, host PCI config | Link/power/riser/card fault; cold cycle may be required |
+| Low performance | power limit, PWRBRK, utilization, topology | Throttling, link/collective bottleneck, runtime settings |
+| Hot while idle | power draw, clocks, processes, airflow | lingering workload/context, persistence behavior, inadequate flow |
+
+## Layered inventory
+
+```bash
+# Host or bare metal
+lspci -nn | grep -iE 'NVIDIA|3D controller'
+
+# Guest/driver
+nvidia-smi -L
+nvidia-smi --query-gpu=index,pci.bus_id,memory.total,pstate,power.draw,power.limit,utilization.gpu,temperature.gpu,temperature.memory --format=csv
+
+# Kernel/module
+modinfo -n nvidia
+sudo dmesg --level=err,warn | grep -Ei 'NVRM|Xid|fallen off|RmInitAdapter|SEC2|AER|RCU'
+```
+
+## Xid 79 and D3cold
+
+**Measured:** after Xid 79, a card remained unavailable through function-level reset, secondary-bus reset, runtime-power changes, and remove/rescan. Its PCI configuration read as an invalid header state until a true cold power cycle.
+
+Recovery order:
+
+1. Stop workloads and shut down the guest and host cleanly.
+2. Remove main power long enough for standby rails to discharge; 30 seconds worked in the measured case.
+3. Restore power and check host `lspci` before starting the VM.
+4. If still missing, isolate card/riser/power using the matrix in [QC](QC.md).
+
+Repeated warm reboots can waste time when the root port or endpoint no longer enumerates.
+
+## A card is physically cold
+
+A cold card during an expected workload usually means it is not drawing workload power. Check, in order:
+
+1. Does the host enumerate it?
+2. Does the guest own it?
+3. Does `nvidia-smi` list it and show a process/utilization?
+4. Does swapping in a known-good riser and power lead change the result?
+5. Does the suspect card fail in a known-good slot/power path?
+
+Change one variable per shutdown. Label every cable and riser before the next swap.

--- a/docs/WORKLOADS.md
+++ b/docs/WORKLOADS.md
@@ -1,0 +1,26 @@
+# Workload matrix
+
+The repository covers more than LLM inference. Each workload track starts with compatibility and memory-fit evidence, then adds a reproducible recipe and measured result.
+
+| Track | Current state | Next evidence needed |
+|---|---|---|
+| LLM inference | Verified on one- and three-card workloads | More model families, concurrency, energy/token |
+| Image generation | Planned | Reproducible SM80 pipeline, images/minute, peak VRAM and power |
+| Video generation | Planned | Reproducible model, resolution/frames, seconds/frame, peak VRAM |
+| CUDA/QC | Initial tools included | Near-full HBM and sustained compute reports from more cards |
+| Fine-tuning/training | Untested | Memory plan, optimizer/quantization, interconnect scaling |
+| Multi-node | Untested | Network/topology and end-to-end scaling data |
+
+Follow the track guides:
+
+- [LLM inference](../workloads/llm/README.md)
+- [Image generation](../workloads/image/README.md)
+- [Video generation](../workloads/video/README.md)
+
+## Qualification order
+
+1. Confirm CUDA/SM80 compatibility.
+2. Calculate static weight fit and reserve runtime/KV/activation memory.
+3. Prefer a single-card correctness run when possible.
+4. Select pipeline/data/tensor parallelism from communication behavior.
+5. Benchmark with thermal, power, quality, and correctness data—not throughput alone.

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,57 @@
+# Result submission format
+
+Create one Markdown file per result. Store small, redacted machine-readable evidence beside it when useful; do not commit model outputs containing private prompts or data.
+
+```markdown
+# Workload — short result name
+
+Status: measured | compatibility-only | failed
+Date: YYYY-MM-DD
+
+## Hardware
+
+- Cards: N × CMP 170HX
+- Anonymous card labels:
+- Topology / PCIe links:
+- Power limit and measured peak draw:
+- Cooling and peak core/memory temperatures:
+
+## Software
+
+- OS / kernel:
+- NVIDIA driver / CUDA:
+- Runtime repository + exact commit or image digest:
+- Model repository + exact revision:
+- Quantization / dtype:
+
+## Command
+
+```text
+copy-pasteable redacted command
+```
+
+## Method
+
+- Warmup:
+- Samples:
+- Input/output tokens, frames, resolution, steps, batch, concurrency:
+- Metric calculation:
+
+## Results
+
+| Metric | Value |
+|---|---:|
+| ... | ... |
+
+## Correctness and failures
+
+- Output validation:
+- Xid/ECC/AER scan:
+- Known caveats:
+
+## Evidence
+
+- Links to raw redacted files or upstream benchmark repository
+```
+
+Before committing, run the publication gate in [AGENTS.md](../AGENTS.md).

--- a/scripts/model-fit.py
+++ b/scripts/model-fit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Estimate whether static model weights fit a GPU topology.
+
+This is a capacity preflight, not a runtime guarantee. It does not model
+quantization workspaces, CUDA graphs, activations, KV cache, or imbalance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("weights_gib", type=float, help="total checkpoint size in GiB")
+    parser.add_argument("--gpus", type=int, default=3, help="GPU count (default: 3)")
+    parser.add_argument("--vram-gib", type=float, default=64.0, help="VRAM per GPU")
+    parser.add_argument(
+        "--reserve-gib",
+        type=float,
+        default=8.0,
+        help="VRAM reserved per GPU for runtime/KV/activations",
+    )
+    args = parser.parse_args()
+
+    if args.weights_gib <= 0 or args.gpus <= 0 or args.vram_gib <= 0:
+        parser.error("weights, GPU count, and VRAM must be positive")
+    if not 0 <= args.reserve_gib < args.vram_gib:
+        parser.error("reserve must be non-negative and smaller than per-GPU VRAM")
+
+    usable_per_gpu = args.vram_gib - args.reserve_gib
+    static_per_gpu = args.weights_gib / args.gpus
+    minimum_gpus = math.ceil(args.weights_gib / usable_per_gpu)
+    margin = usable_per_gpu - static_per_gpu
+
+    print(f"weights:          {args.weights_gib:.2f} GiB")
+    print(f"topology:         {args.gpus} x {args.vram_gib:.2f} GiB")
+    print(f"runtime reserve:  {args.reserve_gib:.2f} GiB/GPU")
+    print(f"static shard:     {static_per_gpu:.2f} GiB/GPU")
+    print(f"usable capacity:  {usable_per_gpu:.2f} GiB/GPU")
+    print(f"static margin:    {margin:.2f} GiB/GPU")
+    print(f"minimum GPUs:     {minimum_gpus} at this reserve")
+    print(f"verdict:          {'STATIC FIT' if margin >= 0 else 'DOES NOT FIT'}")
+    print("warning: runtime overhead and uneven layer/expert placement can still fail")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qc/README.md
+++ b/scripts/qc/README.md
@@ -1,0 +1,32 @@
+# QC scripts
+
+These scripts support a supervised card-acceptance workflow. They do not certify a card and must not run on a GPU that holds a serving or training context.
+
+## Near-full HBM test
+
+Build for SM80:
+
+```bash
+nvcc -O3 -arch=sm_80 scripts/qc/compare_vram.cu -o /tmp/compare-vram
+```
+
+Test one idle card with a 62 GiB allocation:
+
+```bash
+/tmp/compare-vram --device 0 --gib 62
+```
+
+The program fills and verifies every 64-bit word with an index-derived pattern. It checks allocation, kernel-launch, synchronization, and verification errors.
+
+## Supporting checks
+
+```bash
+scripts/qc/pcie-check.sh
+sudo scripts/qc/xid-watch.sh
+```
+
+Run `xid-watch.sh` in another terminal during the memory and compute tests. Keep `nvidia-smi` temperature monitoring visible and apply the stop thresholds from [QC](../../docs/QC.md).
+
+## What is still external
+
+A sustained compute test such as `gpu-burn` is not bundled because compiled third-party binaries should not be copied into this repository. Pin, review, and build the selected tool from its original source; record its commit and command in the result.

--- a/scripts/qc/compare_vram.cu
+++ b/scripts/qc/compare_vram.cu
@@ -1,0 +1,159 @@
+#include <cuda_runtime.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+struct Failure {
+  unsigned long long found;
+  unsigned long long expected;
+  unsigned long long index;
+  int mismatch;
+};
+
+__device__ __forceinline__ unsigned long long pattern(unsigned long long index) {
+  unsigned long long value = index + 0x9e3779b97f4a7c15ULL;
+  value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  value = (value ^ (value >> 27)) * 0x94d049bb133111ebULL;
+  return value ^ (value >> 31);
+}
+
+__global__ void fill(unsigned long long* memory, unsigned long long words) {
+  const unsigned long long start =
+      static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const unsigned long long stride =
+      static_cast<unsigned long long>(blockDim.x) * gridDim.x;
+  for (unsigned long long i = start; i < words; i += stride) {
+    memory[i] = pattern(i);
+  }
+}
+
+__global__ void verify(const unsigned long long* memory,
+                       unsigned long long words,
+                       Failure* failure) {
+  const unsigned long long start =
+      static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const unsigned long long stride =
+      static_cast<unsigned long long>(blockDim.x) * gridDim.x;
+  for (unsigned long long i = start; i < words; i += stride) {
+    const unsigned long long expected = pattern(i);
+    const unsigned long long found = memory[i];
+    if (found != expected && atomicCAS(&failure->mismatch, 0, 1) == 0) {
+      failure->found = found;
+      failure->expected = expected;
+      failure->index = i;
+    }
+  }
+}
+
+static bool cuda_ok(cudaError_t status, const char* operation) {
+  if (status == cudaSuccess) return true;
+  std::fprintf(stderr, "%s failed: %s\n", operation, cudaGetErrorString(status));
+  return false;
+}
+
+static unsigned long long parse_ull(const char* text, const char* option) {
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long value = std::strtoull(text, &end, 10);
+  if (errno != 0 || end == text || *end != '\0') {
+    std::fprintf(stderr, "invalid %s value: %s\n", option, text);
+    std::exit(2);
+  }
+  return value;
+}
+
+int main(int argc, char** argv) {
+  int device = 0;
+  unsigned long long gib = 62;
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--device") == 0 && i + 1 < argc) {
+      device = static_cast<int>(parse_ull(argv[++i], "--device"));
+    } else if (std::strcmp(argv[i], "--gib") == 0 && i + 1 < argc) {
+      gib = parse_ull(argv[++i], "--gib");
+    } else {
+      std::fprintf(stderr, "usage: %s [--device N] [--gib N]\n", argv[0]);
+      return 2;
+    }
+  }
+
+  if (!cuda_ok(cudaSetDevice(device), "cudaSetDevice")) return 1;
+
+  cudaDeviceProp properties{};
+  if (!cuda_ok(cudaGetDeviceProperties(&properties, device),
+               "cudaGetDeviceProperties")) {
+    return 1;
+  }
+
+  size_t free_bytes = 0;
+  size_t total_bytes = 0;
+  if (!cuda_ok(cudaMemGetInfo(&free_bytes, &total_bytes), "cudaMemGetInfo")) {
+    return 1;
+  }
+
+  const unsigned long long bytes = gib * 1024ULL * 1024ULL * 1024ULL;
+  const unsigned long long words = bytes / sizeof(unsigned long long);
+  std::printf("device=%d name=%s requested=%llu GiB free=%.2f GiB total=%.2f GiB\n",
+              device, properties.name, gib,
+              static_cast<double>(free_bytes) / (1024.0 * 1024.0 * 1024.0),
+              static_cast<double>(total_bytes) / (1024.0 * 1024.0 * 1024.0));
+
+  if (bytes > free_bytes) {
+    std::fprintf(stderr, "requested allocation exceeds currently free VRAM\n");
+    return 1;
+  }
+
+  unsigned long long* memory = nullptr;
+  Failure* failure = nullptr;
+  if (!cuda_ok(cudaMalloc(&memory, static_cast<size_t>(bytes)), "cudaMalloc(data)")) {
+    return 1;
+  }
+  if (!cuda_ok(cudaMalloc(&failure, sizeof(Failure)), "cudaMalloc(failure)")) {
+    cudaFree(memory);
+    return 1;
+  }
+  if (!cuda_ok(cudaMemset(failure, 0, sizeof(Failure)), "cudaMemset(failure)")) {
+    cudaFree(failure);
+    cudaFree(memory);
+    return 1;
+  }
+
+  constexpr int threads = 256;
+  const int blocks = properties.multiProcessorCount * 16;
+  fill<<<blocks, threads>>>(memory, words);
+  if (!cuda_ok(cudaGetLastError(), "fill launch") ||
+      !cuda_ok(cudaDeviceSynchronize(), "fill synchronize")) {
+    cudaFree(failure);
+    cudaFree(memory);
+    return 1;
+  }
+
+  verify<<<blocks, threads>>>(memory, words, failure);
+  if (!cuda_ok(cudaGetLastError(), "verify launch") ||
+      !cuda_ok(cudaDeviceSynchronize(), "verify synchronize")) {
+    cudaFree(failure);
+    cudaFree(memory);
+    return 1;
+  }
+
+  Failure host_failure{};
+  const bool copied = cuda_ok(
+      cudaMemcpy(&host_failure, failure, sizeof(Failure), cudaMemcpyDeviceToHost),
+      "cudaMemcpy(failure)");
+  cudaFree(failure);
+  cudaFree(memory);
+  if (!copied) return 1;
+
+  if (host_failure.mismatch != 0) {
+    std::fprintf(stderr,
+                 "FAIL index=%llu expected=0x%016llx found=0x%016llx\n",
+                 host_failure.index, host_failure.expected, host_failure.found);
+    return 1;
+  }
+
+  std::printf("PASS verified %llu GiB (%llu 64-bit words)\n", gib, words);
+  return 0;
+}

--- a/scripts/qc/pcie-check.sh
+++ b/scripts/qc/pcie-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  printf 'nvidia-smi not found\n' >&2
+  exit 1
+fi
+
+printf 'GPU, Bus ID, VRAM, Current Gen, Max Gen, Current Width, Max Width\n'
+nvidia-smi \
+  --query-gpu=index,pci.bus_id,memory.total,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max \
+  --format=csv,noheader
+
+printf '\nPower-brake state:\n'
+nvidia-smi -q | grep -A1 'HW Power Brake Slowdown' || true
+
+printf '\nInterpret links in context: virtualized CMP paths may negotiate below bare-metal capability.\n'

--- a/scripts/qc/xid-watch.sh
+++ b/scripts/qc/xid-watch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( EUID != 0 )); then
+  printf 'Run as root so kernel messages are visible: sudo %s\n' "$0" >&2
+  exit 1
+fi
+
+printf 'Watching for NVIDIA Xid, PCIe, and reset errors. Press Ctrl-C to stop.\n'
+dmesg --follow --human | grep --line-buffered -Ei 'NVRM|Xid|fallen off|RmInitAdapter|SEC2|AER|PCIe Bus Error'

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Local diagnostic report. Review and redact its output before publication.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+section "Operating system"
+uname -srmo
+if [[ -r /etc/os-release ]]; then
+  grep -E '^(NAME|VERSION)=' /etc/os-release
+fi
+
+section "NVIDIA module"
+modinfo nvidia 2>/dev/null | grep -E '^(filename|version):' || true
+
+section "GPU inventory"
+nvidia-smi --query-gpu=index,name,memory.total,pstate,power.draw,power.limit,utilization.gpu,temperature.gpu,temperature.memory --format=csv 2>/dev/null || true
+
+section "PCIe links"
+nvidia-smi --query-gpu=index,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max --format=csv 2>/dev/null || true
+
+section "Power brake"
+nvidia-smi -q 2>/dev/null | grep -A1 'HW Power Brake Slowdown' || true
+
+section "Recent NVIDIA/kernel errors"
+dmesg --level=err,warn 2>/dev/null | grep -Ei 'NVRM|Xid|fallen off|RmInitAdapter|SEC2|AER|RCU' | tail -n 100 || true
+
+printf '\nReview this report for private identifiers before sharing it.\n'

--- a/workloads/image/README.md
+++ b/workloads/image/README.md
@@ -1,0 +1,24 @@
+# Image generation
+
+Status: **planned; no public CMP 170HX result yet**.
+
+The first recipe should favor a widely redistributable SM80-compatible pipeline and record both performance and output correctness.
+
+## Minimum benchmark record
+
+- model and VAE repository + exact revisions;
+- runtime/attention implementation and CUDA versions;
+- resolution, steps, sampler/scheduler, guidance, batch size, seed, and dtype;
+- cold start, warm latency, images/minute, peak VRAM, power, core temperature, and memory temperature;
+- output hashes and a small license-compatible sample set;
+- any CPU/NVMe offload and its effect on latency.
+
+Do not compare images/second across different step counts, resolutions, or quality settings as if they were equivalent.
+
+## Qualification target
+
+1. Single-card correctness at 125 W.
+2. Repeated warm run at 180 W with forced airflow.
+3. Batch/VRAM scaling curve.
+4. Comparison with a controlled reference GPU.
+5. Multi-card independent-job throughput before attempting communication-heavy parallelism.

--- a/workloads/llm/README.md
+++ b/workloads/llm/README.md
@@ -1,0 +1,27 @@
+# LLM inference
+
+LLM inference is the first verified workload track.
+
+## Proven paths
+
+- **Single card:** Qwen3.8-27B NVFP4, measured across three separate cards.
+- **Three cards:** DeepSeek-V4-Flash-0731 using pipeline parallelism.
+- **Compatibility rejection:** GLM-5.3-Flash NVFP4 is an SM121 path, not an SM80 artifact; the examined AWQ alternative does not statically fit three 64 GiB cards with runtime headroom.
+
+See [Benchmarks](../../docs/BENCHMARKS.md) for results and evidence links.
+
+## Recipe order
+
+1. Measure checkpoint size with filesystem bytes, not the model card estimate.
+2. Run `scripts/model-fit.py` with a realistic per-card runtime reserve.
+3. Check runtime support for SM80 and the model architecture/quantization.
+4. Prefer a one-card correctness test; use pipeline parallel first for oversized models on slow PCIe.
+5. Record TTFT/prefill, decode, concurrency, acceptance rate if speculative, power, and temperatures.
+
+Example static check:
+
+```bash
+python3 scripts/model-fit.py 148 --gpus 3 --vram-gib 64 --reserve-gib 8
+```
+
+Static fit is necessary but insufficient. CUDA graphs, KV cache, expert placement, and uneven layer sizes can still cause out-of-memory failures.

--- a/workloads/video/README.md
+++ b/workloads/video/README.md
@@ -1,0 +1,24 @@
+# Video generation
+
+Status: **planned; no public CMP 170HX result yet**.
+
+Video pipelines combine large weights, long-lived activations, host-memory pressure, and expensive output validation. Capacity alone does not guarantee useful throughput.
+
+## Minimum benchmark record
+
+- model repository + exact revision and component dtypes;
+- runtime commit, attention backend, and offload settings;
+- width, height, frame count, FPS, steps, guidance, seed, and batch;
+- load time, generation wall time, seconds/frame, peak VRAM, host RAM, power, and temperatures;
+- output checksum, decode success, duration, and a license-compatible sample;
+- storage read/write volume when components are offloaded.
+
+## Qualification target
+
+1. Preflight static weights and host-memory requirements.
+2. Single-card short-clip correctness.
+3. Long-clip thermal and memory-stability run.
+4. Repeatability at fixed seed and settings.
+5. Multi-card component/pipeline experiment only after measuring transfer cost.
+
+Do not publish a speed number without resolution, frame count, steps, and quality settings beside it.


### PR DESCRIPTION
## Summary

- establish a brandable public home for CMP 170HX AI workloads without importing private repository history
- consolidate the verified Proxmox, driver, power, cooling, QC, troubleshooting, and LLM benchmark findings
- add strict agent publication rules plus reusable inventory, model-fit, PCIe, Xid, and near-full-HBM validation tools

## Test plan

- [x] Run `git diff --check` and review the complete branch diff
- [x] Run shell syntax checks and the model-fit example
- [x] Scan tracked files and history for secrets, infrastructure identifiers, symlinks, and large artifacts
- [ ] Compile `scripts/qc/compare_vram.cu` with CUDA `nvcc` on an SM80 host
- [ ] Run the destructive near-full-HBM test only on an idle, supervised card with forced airflow