### PR TITLE
feat: enable automated PR-Agent reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: pr-review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+# Granted at the caller level because reusable workflows can only downscope.
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-review:
+    uses: PixelML/pr-agent/.github/workflows/pr-review-reusable.yml@5fe2fbb8cdb9253fa8b3cf560f74f81980262c6b
+    with:
+      auto_review: true
+      auto_describe: false
+      auto_improve: false
+    secrets:
+      CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,19 @@
+# Per-repo overrides for PixelML pr-agent. See:
+# https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+
+[pr_reviewer]
+require_tests_review = false
+require_estimate_effort_to_review = true
+num_max_findings = 8
+extra_instructions = """
+This repository documents CMP 170HX (mining-card) experiments on DGX-class
+and custom hardware. Focus on factual accuracy of measured claims, safe
+power/thermal handling guidance, and reproducibility of benchmark recipes.
+Flag missing disclaimers on destructive memory tests or power-limit changes.
+"""
+
+[ignore]
+glob = [
+  "reports/**",
+  "**/*.lock",
+]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -6,14 +6,51 @@ require_tests_review = false
 require_estimate_effort_to_review = true
 num_max_findings = 8
 extra_instructions = """
-This repository documents CMP 170HX (mining-card) experiments on DGX-class
-and custom hardware. Focus on factual accuracy of measured claims, safe
-power/thermal handling guidance, and reproducibility of benchmark recipes.
-Flag missing disclaimers on destructive memory tests or power-limit changes.
+This public repository is the platform-wide knowledge base for CMP 170HX
+hardware, setup, safety, quality control, and workload results. AGENTS.md is
+the publication and evidence contract; detailed model-family experiments live
+in linked repositories rather than here.
+
+When reviewing, prioritize these repository-specific risks:
+
+1. Publication boundary. Treat exposure prohibited by AGENTS.md as a BLOCKER,
+including credentials, private infrastructure identifiers, raw logs, and
+redistribution-restricted artifacts. Review filenames and assets as well as
+text, especially assets/ and results/.
+
+2. Evidence labels and receipts. Claims in README.md and docs/BENCHMARKS.md
+must distinguish measured, inferred, community-reported, and untested results.
+Flag benchmark numbers without reproducible workload shape, revision, topology,
+card count, power limit, thermal data, or a redacted primary receipt.
+
+3. Hardware safety. Changes to docs/HARDWARE.md,
+docs/COOLING-AND-POWER.md, docs/QC.md, and scripts/qc/ must preserve forced
+airflow guidance and the 80 C core / 85 C memory stop limits. Flag advice that
+can load, flash, power-cycle, or destructively test cards without explicit
+preconditions and abort behavior.
+
+4. Reproducibility. Commands in docs/INSTALLATION.md,
+docs/TROUBLESHOOTING.md, scripts/, and workload READMEs must be copy-pasteable,
+revision-pinned where appropriate, and fail safely. Flag mutable dependencies,
+unchecked downloads, misleading defaults, and scripts that continue after a
+failed hardware or storage check.
+
+5. Repository routing. README.md, docs/WORKLOADS.md, and workload index pages
+should keep compact platform-level conclusions and link detailed experiments
+to the correct model-family repository. Flag copied private history, duplicate
+recipes, broken links, or conclusions that overreach the cited attempt.
+
+6. Code and documentation hygiene. For shell scripts, require strict error
+handling, safe quoting, bounded waits, and no secret-bearing command lines.
+For Python/CUDA helpers, flag silent failures, unsafe device assumptions, and
+results that could be mistaken for benchmark evidence without validation.
 """
 
-[ignore]
-glob = [
-  "reports/**",
-  "**/*.lock",
-]
+[pr_description]
+extra_instructions = """
+The PR description should state:
+- which platform guide, workload index, script, or evidence set changed;
+- whether each technical claim is measured, inferred, community-reported, or untested;
+- the exact public source/receipt for new numbers or compatibility claims;
+- the safety and publication-boundary checks run before publishing.
+"""


### PR DESCRIPTION
## Summary

- Add a SHA-pinned caller for the central PR-Agent workflow with only the named ClipProxy secret mapped.
- Add a repository-specific review policy for publication safety, measured evidence, thermal limits, reproducibility, and repository routing.
- Use this PR as the controlled pre-merge proof of the central ClipProxy auth path.

## Test plan

- [x] Parse the workflow YAML and PR-Agent TOML.
- [x] Run git diff --check, publication-boundary scans, and large-file/symlink checks.
- [ ] Confirm the PR-Agent workflow succeeds and posts a Reviewer Guide for this exact head.
- [ ] Obtain independent exact-head review after the bot result.
- [ ] Re-pin to the merged PixelML/pr-agent main SHA before merge.