### PR TITLE
docs: add four-card cooling note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,13 @@ Contributions are welcome: reproducible benchmarks, card-validation data, coolin
 
 Small, evidence-backed changes are easier to review than broad claims. Negative results are welcome when the environment and failure mode are documented.
 
+## Where experiment results live
+
+One dedicated repository per model family or workload (see the map in
+[README](README.md#model-family-repositories)). Do not create per-quantization,
+per-runtime, or per-machine repositories; put every attempt for a model family in
+that family's repository and link it from the table above.
+
 ## Commit style
 
 Use a short Conventional Commit subject, for example:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The CMP 170HX shares useful traits with A100-class hardware, including SM80 comp
 
 I traded out three RTX 3090s and rebuilt this node around four CMP 170HXs. The reason was simple: the four cards expose 256 GiB of aggregate HBM in one box. The lab still has RTX 3090 cards and DGX Spark systems, giving us useful comparison points for consumer CUDA, low-cost SM80/HBM, and GB10. DGX Spark notes live in [club-dgx-spark](https://github.com/PixelML/club-dgx-spark).
 
-**Measured on 2026-08-30:** all four cards enumerated in one Ubuntu guest with driver 610.43.03 and reported 65,536 MiB each. With a 180 W cap, the idle snapshot showed 31–32 °C core temperatures, 35–45 °C memory temperatures, 32–36 W per card, zero memory use, and zero GPU utilization. This is a bring-up result, not a four-card performance benchmark.
+**Measured on 2026-08-30:** all four cards enumerated in one Ubuntu guest with driver 610.43.03 and reported 65,536 MiB each. This is a bring-up inventory, not a four-card performance benchmark. Under the current build (four cards in an open frame with one 80 mm blower on a printed duct), a later idle snapshot the same day showed 37–38 °C cores, 41–51 °C memory temperatures, and about 141 W for the group at zero utilization. Cooling and power details are in [Cooling and power](docs/COOLING-AND-POWER.md).
 
 ## Verified baseline
 

--- a/README.md
+++ b/README.md
@@ -51,16 +51,15 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 ### PixelML measurements
 
-| Workload | Topology and power | Decode | Prefill and latency | Evidence |
-|---|---|---:|---:|---|
-| Qwen3.8-27B W4A16 + DFlash2 | 1 card at a time, 3 cards tested, 180 W cap | **136.4 tok/s mean** (133.6–140.3) for 256-token generations | 1,926–1,957 tok/s at 6.6K context; 181–201 ms TTFT | [Pinned results](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md) (1) |
-| DeepSeek-V4-Flash-0731 native weights + DSpark | 3 cards, pipeline parallel, 180 W/card | **83.3 tok/s aggregate** across three 400-token prompts | **2,965 tok/s** at 5.4K context | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) (2) |
+Publication gate: a number appears in this section only with sanitized raw receipts and a stable evidence pin. Two internal results are currently withheld under that gate:
+
+| Workload | Status | Missing before numbers can be published |
+|---|---|---|
+| DeepSeek-V4-Flash-0731 native weights + DSpark, 3-card pipeline | Result exists; numbers withheld | redacted raw JSONL receipts and a complete run manifest at an exact revision |
+| Qwen3.8-27B W4A16 + DFlash2, three single-card runs | Result exists; numbers withheld | owner-approved repair of the evidence history (the current revision contains prohibited identifiers), then a sanitized re-pin |
 
 GLM-5.3-Flash remains a compatibility result rather than a speed result: no completed CMP 170HX serving run has been published. See the [negative-result notes](docs/BENCHMARKS.md#negative-results-matter).
 
-(1) The pinned Qwen revision summarizes the measured numbers, but its raw artifact files still contain prohibited infrastructure identifiers. Publishing a sanitized replacement revision requires an owner-approved history repair in that repository; this link will be re-pinned to the repaired revision. Until then, do not open the raw artifact files in that pin.
-
-(2) Claim not ready: the pinned DeepSeek revision (`5c5b5a4`) contains only a summary and launch scripts — no redacted raw JSON/JSONL receipts, run manifest, or complete environment metadata. The figures above are quoted from that summary; treat the row as unverified until a sanitized raw-evidence revision is published.
 
 ### Community reference
 
@@ -80,10 +79,9 @@ Do not compare these rows as a leaderboard. The models, prompts, context lengths
 
 | Lane | Evidence | Current guidance |
 |---|---|---|
-| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Measured by PixelML:** 83.3 tok/s on 3 cards (raw receipts pending; see note 2) | Fastest published PixelML large-model result on this node — throughput-only evidence, no quality or reliability floor yet. Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. |
-| Qwen3.8-27B W4A16 AutoRound + W4A16 DFlash2 | **Measured by PixelML:** 136.4 tok/s mean across 3 independently tested cards | Fastest published PixelML single-card result in this table — throughput-only evidence. This is W4A16, not NVFP4; correct usage-token counting and the prepared fast variant both matter. |
+| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Internal result, receipts pending** — no club-published number | Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. Source-build the SM80 operators; a precompiled image with only Python overlays failed during graph capture. |
 | GLM-5.2 symmetric Int4/Int8 mix with an unquantized MTP head | **Community-reported:** 28.47 tok/s baseline on 8 CMP 170HX cards; MTP serving initialization verified | Useful SM80 reference for future DSA models, but not a four-card recipe. The [pinned vLLM composition](https://github.com/allover326/vllm-dsa-mtp-sm80/blob/56bba6097b06b3c0d981de3a6cef63ed394d2626/README.md) combines a Triton sparse-MLA backend with MTP under pipeline parallelism. |
-| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md):** no completed serving result at pin `a2f22cc` | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. A 146.05 GiB UD-IQ4_XS GGUF candidate and an SM80 llama.cpp-fork build exist but are **serving-untested**; live status is tracked in the model repository. |
+| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/07b28e6d8d3b9fe7cb8a69f37e36088ffa71cec8/README.md):** no completed serving result at pin `07b28e6` | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. |
 | W4AFP8 or other FP8-activation quants | **Community-reported:** the tested GLM-5.2 paths require SM89 or newer | Reject at the fit gate unless the runtime documents an SM80-safe implementation. This does not rule out FP8 KV: the DeepSeek-V4 run above used FP8 KV successfully on SM80. |
 
 Five rules keep repeating across our attempts and the community work:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 ## Published workload results
 
-### PixelML measurements
+### PixelML result registry
 
 Publication gate: a number appears in this section only with sanitized raw receipts and a stable evidence pin. Two internal results are currently withheld under that gate:
 
@@ -79,17 +79,17 @@ Do not compare these rows as a leaderboard. The models, prompts, context lengths
 
 | Lane | Evidence | Current guidance |
 |---|---|---|
-| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Internal result, receipts pending** — no club-published number | Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. Source-build the SM80 operators; a precompiled image with only Python overlays failed during graph capture. |
+| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Internal result, receipts pending** — no club-published claims | Untested proposals for the eventual run: pipeline parallelism, a rebalanced final-rank layer split such as `15,15,13`, DSpark `k=5`, and FP8 KV. SM80-safe operator builds are an open question this configuration must answer. |
 | GLM-5.2 symmetric Int4/Int8 mix with an unquantized MTP head | **Community-reported:** 28.47 tok/s baseline on 8 CMP 170HX cards; MTP serving initialization verified | Useful SM80 reference for future DSA models, but not a four-card recipe. The [pinned vLLM composition](https://github.com/allover326/vllm-dsa-mtp-sm80/blob/56bba6097b06b3c0d981de3a6cef63ed394d2626/README.md) combines a Triton sparse-MLA backend with MTP under pipeline parallelism. |
-| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/07b28e6d8d3b9fe7cb8a69f37e36088ffa71cec8/README.md):** no completed serving result at pin `07b28e6` | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. |
-| W4AFP8 or other FP8-activation quants | **Community-reported:** the tested GLM-5.2 paths require SM89 or newer | Reject at the fit gate unless the runtime documents an SM80-safe implementation. This does not rule out FP8 KV: the DeepSeek-V4 run above used FP8 KV successfully on SM80. |
+| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/58eece6db097fb1d5e0a767b752fd1c040b3ac58/README.md):** no completed serving result at pin `58eece6` | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. |
+| W4AFP8 or other FP8-activation quants | **Community-reported:** the tested GLM-5.2 paths require SM89 or newer | Reject at the fit gate unless the runtime documents an SM80-safe implementation. Whether FP8 KV cache works on SM80 is an open question until the DeepSeek receipts land. |
 
 Five rules keep repeating across our attempts and the community work:
 
 1. Start with pipeline parallelism, not tensor parallelism, when cards communicate over slow PCIe without P2P.
 2. Rebalance the final pipeline rank when it also holds the LM head or speculative draft; default equal splits can fail even when total VRAM is sufficient.
 3. Check the quant details, not only the bit count. Symmetric versus asymmetric MoE weights, activation format, KV format, and whether the draft head is quantized can change compatibility.
-4. Match the build to the patch. Our DeepSeek-V4 run required compiled SM80 operators; a precompiled image that applied only Python overlays failed during graph capture.
+4. Match the build to the patch: if compiled SM80 operators are required, a precompiled image that applies only Python overlays is a known failure mode (**untested proposal for this node**).
 5. Verify composed patches with import and undefined-name checks, not only syntax compilation. The community composition includes this gate after a real missing-helper failure.
 
 ## Repository map

--- a/README.md
+++ b/README.md
@@ -53,14 +53,18 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 | Workload | Topology and power | Decode | Prefill and latency | Evidence |
 |---|---|---:|---:|---|
-| Qwen3.8-27B W4A16 + DFlash2 | 1 card at a time, 3 cards tested, 180 W cap | **136.4 tok/s mean** (133.6–140.3) for 256-token generations | 1,926–1,957 tok/s at 6.6K context; 181–201 ms TTFT | [Pinned results](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md) |
-| DeepSeek-V4-Flash-0731 native weights + DSpark | 3 cards, pipeline parallel, 180 W/card | **83.3 tok/s aggregate** across three 400-token prompts | **2,965 tok/s** at 5.4K context | [Pinned results](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/blob/5c5b5a4b45e8def82ec027737df616c55f997963/RESULTS.md) |
+| Qwen3.8-27B W4A16 + DFlash2 | 1 card at a time, 3 cards tested, 180 W cap | **136.4 tok/s mean** (133.6–140.3) for 256-token generations | 1,926–1,957 tok/s at 6.6K context; 181–201 ms TTFT | [Pinned results](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md) (1) |
+| DeepSeek-V4-Flash-0731 native weights + DSpark | 3 cards, pipeline parallel, 180 W/card | **83.3 tok/s aggregate** across three 400-token prompts | **2,965 tok/s** at 5.4K context | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) (2) |
 
 GLM-5.3-Flash remains a compatibility result rather than a speed result: no completed CMP 170HX serving run has been published. See the [negative-result notes](docs/BENCHMARKS.md#negative-results-matter).
 
+(1) The pinned Qwen revision summarizes the measured numbers, but its raw artifact files still contain prohibited infrastructure identifiers. Publishing a sanitized replacement revision requires an owner-approved history repair in that repository; this link will be re-pinned to the repaired revision. Until then, do not open the raw artifact files in that pin.
+
+(2) Claim not ready: the pinned DeepSeek revision (`5c5b5a4`) contains only a summary and launch scripts — no redacted raw JSON/JSONL receipts, run manifest, or complete environment metadata. The figures above are quoted from that summary; treat the row as unverified until a sanitized raw-evidence revision is published.
+
 ### Community reference
 
-**Community-reported, not independently reproduced by PixelML:** [allover326's four-card DeepSeek-V4-Flash run](https://github.com/allover326/deepseek-v4-cmp170hx/tree/3dd2d8817e7deae00d998edde0d227e7254ea71e) used pipeline parallelism and DSpark at 180 W/card.
+**Community-reported, not independently reproduced by PixelML.** The pinned source history contains prohibited identifiers pending an owner-approved repair there, so treat its figures as reported-only: [allover326's four-card DeepSeek-V4-Flash run](https://github.com/allover326/deepseek-v4-cmp170hx/tree/3dd2d8817e7deae00d998edde0d227e7254ea71e) used pipeline parallelism and DSpark at 180 W/card.
 
 | Decode | Prefill and latency | Long context | Evidence |
 |---:|---:|---:|---|
@@ -68,19 +72,21 @@ GLM-5.3-Flash remains a compatibility result rather than a speed result: no comp
 
 At roughly 1.04M tokens, that community run measured 1,904 tok/s prefill, about 550 seconds to first token, and 35.6 tok/s decode. Retrieval accuracy also fell from about 100% at 150K to 30% at 900K, so the maximum window is a capacity result, not a claim that every token remains equally useful.
 
+The 98.1 tok/s decode figure is a single reported aggregate (n=1 per content class). The same source reports the unchanged server swinging 101.9–130.6 tok/s across runs and requires at least three aggregates, or many fixed-prompt runs, before treating a number as comparable. Read it as indicative, not as a controlled measurement.
+
 Do not compare these rows as a leaderboard. The models, prompts, context lengths, concurrency, and runtime patches differ. Decode rates above use generated-token counts from the final usage result or a fixed output count; they do not count streaming events as tokens.
 
 ### Model, quant, and runtime strategy
 
 | Lane | Evidence | Current guidance |
 |---|---|---|
-| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Measured by PixelML:** 83.3 tok/s on 3 cards | Best published large-model lane on this node. Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. |
-| Qwen3.8-27B W4A16 AutoRound + W4A16 DFlash2 | **Measured by PixelML:** 136.4 tok/s mean across 3 independently tested cards | Best published single-card speed lane. This is W4A16, not NVFP4; correct usage-token counting and the prepared fast variant both matter. |
+| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Measured by PixelML:** 83.3 tok/s on 3 cards (raw receipts pending; see note 2) | Fastest published PixelML large-model result on this node — throughput-only evidence, no quality or reliability floor yet. Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. |
+| Qwen3.8-27B W4A16 AutoRound + W4A16 DFlash2 | **Measured by PixelML:** 136.4 tok/s mean across 3 independently tested cards | Fastest published PixelML single-card result in this table — throughput-only evidence. This is W4A16, not NVFP4; correct usage-token counting and the prepared fast variant both matter. |
 | GLM-5.2 symmetric Int4/Int8 mix with an unquantized MTP head | **Community-reported:** 28.47 tok/s baseline on 8 CMP 170HX cards; MTP serving initialization verified | Useful SM80 reference for future DSA models, but not a four-card recipe. The [pinned vLLM composition](https://github.com/allover326/vllm-dsa-mtp-sm80/blob/56bba6097b06b3c0d981de3a6cef63ed394d2626/README.md) combines a Triton sparse-MLA backend with MTP under pipeline parallelism. |
-| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md):** no completed serving result | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. |
+| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md):** no completed serving result at pin `a2f22cc` | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. A 146.05 GiB UD-IQ4_XS GGUF candidate and an SM80 llama.cpp-fork build exist but are **serving-untested**; live status is tracked in the model repository. |
 | W4AFP8 or other FP8-activation quants | **Community-reported:** the tested GLM-5.2 paths require SM89 or newer | Reject at the fit gate unless the runtime documents an SM80-safe implementation. This does not rule out FP8 KV: the DeepSeek-V4 run above used FP8 KV successfully on SM80. |
 
-Three rules keep repeating across our attempts and the community work:
+Five rules keep repeating across our attempts and the community work:
 
 1. Start with pipeline parallelism, not tensor parallelism, when cards communicate over slow PCIe without P2P.
 2. Rebalance the final pipeline rank when it also holds the LM head or speculative draft; default equal splits can fail even when total VRAM is sufficient.
@@ -96,6 +102,14 @@ scripts/    Read-only inventory, model-fit, and card-validation helpers
 workloads/  LLM, image, and video workload recipes and status
 results/    Submission format for reproducible community results
 ```
+
+## Model-family repositories
+
+Experiments live in one dedicated repository per model family or workload —
+for example [GLM-5.3-Flash-CMP-170HX](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX)
+holds every GLM-5.3-Flash attempt (NVFP4, AWQ, GPTQ, EXL3, FP8/BF16, all runtimes,
+successes, and failures). Never one repository per quantization, checkpoint, runtime,
+or machine; this repository indexes results and holds cross-workload guidance.
 
 ## Safety first
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ At roughly 1.04M tokens, that community run measured 1,904 tok/s prefill, about 
 
 Do not compare these rows as a leaderboard. The models, prompts, context lengths, concurrency, and runtime patches differ. Decode rates above use generated-token counts from the final usage result or a fixed output count; they do not count streaming events as tokens.
 
+### Model, quant, and runtime strategy
+
+| Lane | Evidence | Current guidance |
+|---|---|---|
+| DeepSeek-V4 native checkpoint (MXFP4 experts + FP8 attention) with DSpark | **Measured by PixelML:** 83.3 tok/s on 3 cards | Best published large-model lane on this node. Start with pipeline parallelism, `15,15,13` layer placement, DSpark `k=5`, and FP8 KV. |
+| Qwen3.8-27B W4A16 AutoRound + W4A16 DFlash2 | **Measured by PixelML:** 136.4 tok/s mean across 3 independently tested cards | Best published single-card speed lane. This is W4A16, not NVFP4; correct usage-token counting and the prepared fast variant both matter. |
+| GLM-5.2 symmetric Int4/Int8 mix with an unquantized MTP head | **Community-reported:** 28.47 tok/s baseline on 8 CMP 170HX cards; MTP serving initialization verified | Useful SM80 reference for future DSA models, but not a four-card recipe. The [pinned vLLM composition](https://github.com/allover326/vllm-dsa-mtp-sm80/blob/56bba6097b06b3c0d981de3a6cef63ed394d2626/README.md) combines a Triton sparse-MLA backend with MTP under pipeline parallelism. |
+| GLM-5.3-Flash NVFP4, EXL3, and AWQ attempts | **[PixelML stable summary](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md):** no completed serving result | Keep these as fit/runtime investigations. Do not publish throughput until a checkpoint both fits and reaches an SM80-capable serving path. |
+| W4AFP8 or other FP8-activation quants | **Community-reported:** the tested GLM-5.2 paths require SM89 or newer | Reject at the fit gate unless the runtime documents an SM80-safe implementation. This does not rule out FP8 KV: the DeepSeek-V4 run above used FP8 KV successfully on SM80. |
+
+Three rules keep repeating across our attempts and the community work:
+
+1. Start with pipeline parallelism, not tensor parallelism, when cards communicate over slow PCIe without P2P.
+2. Rebalance the final pipeline rank when it also holds the LM head or speculative draft; default equal splits can fail even when total VRAM is sufficient.
+3. Check the quant details, not only the bit count. Symmetric versus asymmetric MoE weights, activation format, KV format, and whether the draft head is quantized can change compatibility.
+4. Match the build to the patch. Our DeepSeek-V4 run required compiled SM80 operators; a precompiled image that applied only Python overlays failed during graph capture.
+5. Verify composed patches with import and undefined-name checks, not only syntax compilation. The community composition includes this gate after a real missing-helper failure.
+
 ## Repository map
 
 ```text

--- a/README.md
+++ b/README.md
@@ -49,13 +49,26 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 ## Published workload results
 
-| Workload | Topology | Result | Evidence |
-|---|---:|---:|---|
-| Qwen3.8-27B NVFP4 | 1 card | 136.38 tok/s mean at 180 W across three cards | [Benchmark repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
-| DeepSeek-V4-Flash-0731 | 3 cards, pipeline parallel | 83.3 tok/s aggregate decode at 180 W/card | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
-| GLM-5.3-Flash NVFP4 | 3 cards | Not compatible: SM121-format weights and runtime path | [Compatibility notes](docs/BENCHMARKS.md#negative-results-matter) |
+### PixelML measurements
 
-These are measured application results, not theoretical peaks. The linked repositories contain commands, model/runtime pins, per-run outputs, and known caveats.
+| Workload | Topology and power | Decode | Prefill and latency | Evidence |
+|---|---|---:|---:|---|
+| Qwen3.8-27B W4A16 + DFlash2 | 1 card at a time, 3 cards tested, 180 W cap | **136.4 tok/s mean** (133.6–140.3) for 256-token generations | 1,926–1,957 tok/s at 6.6K context; 181–201 ms TTFT | [Pinned results](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md) |
+| DeepSeek-V4-Flash-0731 native weights + DSpark | 3 cards, pipeline parallel, 180 W/card | **83.3 tok/s aggregate** across three 400-token prompts | **2,965 tok/s** at 5.4K context | [Pinned results](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/blob/5c5b5a4b45e8def82ec027737df616c55f997963/RESULTS.md) |
+
+GLM-5.3-Flash remains a compatibility result rather than a speed result: no completed CMP 170HX serving run has been published. See the [negative-result notes](docs/BENCHMARKS.md#negative-results-matter).
+
+### Community reference
+
+**Community-reported, not independently reproduced by PixelML:** [allover326's four-card DeepSeek-V4-Flash run](https://github.com/allover326/deepseek-v4-cmp170hx/tree/3dd2d8817e7deae00d998edde0d227e7254ea71e) used pipeline parallelism and DSpark at 180 W/card.
+
+| Decode | Prefill and latency | Long context | Evidence |
+|---:|---:|---:|---|
+| **98.1 tok/s** single-stream aggregate; **712.8 tok/s** at 64 concurrent requests | **5,207 tok/s** at 77K context; 14.6 s TTFT at 100K in the PP/TP sweep | 1,047,736-token one-shot prefill; 1,002,852-token accumulated conversation with row chunk 64 | [Pinned results](https://github.com/allover326/deepseek-v4-cmp170hx/blob/3dd2d8817e7deae00d998edde0d227e7254ea71e/RESULTS.md) |
+
+At roughly 1.04M tokens, that community run measured 1,904 tok/s prefill, about 550 seconds to first token, and 35.6 tok/s decode. Retrieval accuracy also fell from about 100% at 150K to 30% at 900K, so the maximum window is a capacity result, not a claim that every token remains equally useful.
+
+Do not compare these rows as a leaderboard. The models, prompts, context lengths, concurrency, and runtime patches differ. Decode rates above use generated-token counts from the final usage result or a fixed output count; they do not count streaming events as tokens.
 
 ## Repository map
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,48 +2,21 @@
 
 Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates.
 
-## Qwen3.8-27B W4A16 (AutoRound) + DFlash2, one card
+## Withheld pending publication-safe evidence
 
-Quantization is W4A16 for both the target (AutoRound checkpoint) and the DFlash2 draft — not NVFP4.
+**Qwen3.8-27B W4A16 + DFlash2, three single-card runs:** a three-card result exists, but its current evidence revision contains prohibited infrastructure identifiers and requires an owner-approved history repair before a sanitized re-pin. Numbers and evidence links return here only after that repair.
 
-**Measured:** three separate CMP 170HX cards at a 180 W limit.
-
-| Card | Decode, 256 output tokens | Decode, 900 output tokens | TTFT | Prefill |
-|---|---:|---:|---:|---:|
-| 0 | 135.31 tok/s | 121.28 tok/s | 201.2 ms | 1,957.3 tok/s |
-| 1 | 140.27 tok/s | 124.78 tok/s | 189.7 ms | 1,954.7 tok/s |
-| 2 | 133.57 tok/s | 119.94 tok/s | 181.4 ms | 1,926.0 tok/s |
-| Mean | **136.38 tok/s** | **122.00 tok/s** | **190.8 ms** | **1,946.0 tok/s** |
-
-Peak observed core temperature was 51 °C; peak observed memory temperature across the three runs was 61 °C. A single-card hosted reference reported 147.7 tok/s at 255 W; it is context, not a controlled apples-to-apples comparison.
-
-Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX @ `41d2c41`](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md). The raw artifact files at that pin contain prohibited identifiers pending an owner-approved history repair; use the summary until a sanitized re-pin replaces it.
-
-## DeepSeek-V4-Flash-0731, three cards
-
-**Measured:** 3 × 64 GiB cards, pipeline parallel size 3, 180 W/card, FP8 KV cache, 16,384 maximum sequence length, and speculative decoding with `k=5`.
-
-| Prompt class | Decode throughput |
-|---|---:|
-| Technical | 73.4 tok/s |
-| Prose | 72.4 tok/s |
-| Code | 116.6 tok/s |
-| Aggregate | **83.3 tok/s** |
-
-Measured prefill reached 2,965 tok/s at 5,399 input tokens. Draft-token acceptance ranged from 5.07 to 5.32 tokens, or roughly 81–86%. The 48-shard checkpoint was about 148 GB. Cold startup included approximately 22 minutes of weight loading from shared storage plus approximately seven minutes of CUDA graph capture.
-
-The precompiled runtime image lacked `vllm._C` for this path; a source build was required. Full details: [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX @ `5c5b5a4`](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/blob/5c5b5a4b45e8def82ec027737df616c55f997963/RESULTS.md) — summary only; redacted raw receipts and a run manifest are still required before treating these numbers as claim-ready.
+**DeepSeek-V4-Flash-0731, three-card pipeline:** a three-card result exists, but the current evidence pin has no redacted raw JSONL receipts, run manifest, or complete environment metadata. Numbers return here only after sanitized receipts land at an exact revision.
 
 ## Negative results matter
 
 ### GLM-5.3-Flash (all quantizations)
 
-**Compatibility result, not a performance result.** As of the stable summary at [GLM-5.3-Flash-CMP-170HX @ `a2f22cc`](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md), no completed serving run has been published:
+**Compatibility result, not a performance result.** As of the stable summary at [GLM-5.3-Flash-CMP-170HX @ `07b28e6`](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/07b28e6d8d3b9fe7cb8a69f37e36088ffa71cec8/README.md), no completed serving run has been published:
 
 - NVFP4 targets an SM121 runtime path — incompatible with SM80 (**measured** registry check). Upstream vLLM support ([PR 53906](https://github.com/vllm-project/vllm/pull/53906)) is open and SM90+.
 - AWQ INT4 is 198.1 GiB — over the 192 GiB three-card total before KV (**measured** blob sizes).
-- EXL3/TR3 4 bpw is 175.64 GB = 163.6 GiB — static fit is borderline-negative once overhead is added (**measured** bytes; fit **inferred**), and its kernels ship SM121-only.
-- A 146.05 GiB UD-IQ4_XS GGUF would fit statically (**inferred**), and an SM80 llama.cpp-fork build exists at `0069971` — both **serving-untested**; llama.cpp support PR 27754 is draft.
+- EXL3/TR3 4 bpw is 175,642,157,752 bytes = 163.58 GiB, or 54.53 GiB/card at TP=3 — static weights fit the 64 GiB/card budget with about 9.47 GiB/card of headroom before overhead (**measured** bytes; fit **inferred**). Runtime and overhead feasibility are **untested**, and its kernels ship SM121-only.
 
 Do not advertise a throughput number until a compatible model format, runtime path, and memory plan are demonstrated.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,7 +2,9 @@
 
 Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates.
 
-## Qwen3.8-27B NVFP4, one card
+## Qwen3.8-27B W4A16 (AutoRound) + DFlash2, one card
+
+Quantization is W4A16 for both the target (AutoRound checkpoint) and the DFlash2 draft — not NVFP4.
 
 **Measured:** three separate CMP 170HX cards at a 180 W limit.
 
@@ -15,7 +17,7 @@ Results here are application measurements on the tested CMP 170HX setup. They ar
 
 Peak observed core temperature was 51 °C; peak observed memory temperature across the three runs was 61 °C. A single-card hosted reference reported 147.7 tok/s at 255 W; it is context, not a controlled apples-to-apples comparison.
 
-Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX).
+Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX @ `41d2c41`](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md). The raw artifact files at that pin contain prohibited identifiers pending an owner-approved history repair; use the summary until a sanitized re-pin replaces it.
 
 ## DeepSeek-V4-Flash-0731, three cards
 
@@ -30,13 +32,18 @@ Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com
 
 Measured prefill reached 2,965 tok/s at 5,399 input tokens. Draft-token acceptance ranged from 5.07 to 5.32 tokens, or roughly 81–86%. The 48-shard checkpoint was about 148 GB. Cold startup included approximately 22 minutes of weight loading from shared storage plus approximately seven minutes of CUDA graph capture.
 
-The precompiled runtime image lacked `vllm._C` for this path; a source build was required. Full details: [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX).
+The precompiled runtime image lacked `vllm._C` for this path; a source build was required. Full details: [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX @ `5c5b5a4`](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/blob/5c5b5a4b45e8def82ec027737df616c55f997963/RESULTS.md) — summary only; redacted raw receipts and a run manifest are still required before treating these numbers as claim-ready.
 
 ## Negative results matter
 
-### GLM-5.3-Flash NVFP4
+### GLM-5.3-Flash (all quantizations)
 
-**Compatibility result, not a performance result:** the published NVFP4 artifact targets an SM121 runtime path and is not directly compatible with the SM80 CMP 170HX. An AWQ INT4 alternative was measured at about 198.1 GiB of safetensors, or roughly 66 GiB per card under simple three-way sharding before runtime/KV overhead, so it does not fit 3 × 64 GiB as-is.
+**Compatibility result, not a performance result.** As of the stable summary at [GLM-5.3-Flash-CMP-170HX @ `a2f22cc`](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/a2f22cc9641c3a95c841c6b06d58c6dcabb0f92e/README.md), no completed serving run has been published:
+
+- NVFP4 targets an SM121 runtime path — incompatible with SM80 (**measured** registry check). Upstream vLLM support ([PR 53906](https://github.com/vllm-project/vllm/pull/53906)) is open and SM90+.
+- AWQ INT4 is 198.1 GiB — over the 192 GiB three-card total before KV (**measured** blob sizes).
+- EXL3/TR3 4 bpw is 175.64 GB = 163.6 GiB — static fit is borderline-negative once overhead is added (**measured** bytes; fit **inferred**), and its kernels ship SM121-only.
+- A 146.05 GiB UD-IQ4_XS GGUF would fit statically (**inferred**), and an SM80 llama.cpp-fork build exists at `0069971` — both **serving-untested**; llama.cpp support PR 27754 is draft.
 
 Do not advertise a throughput number until a compatible model format, runtime path, and memory plan are demonstrated.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,8 +1,8 @@
 # Benchmarks
 
-Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates.
+Results here are a publication-status registry for the tested CMP 170HX setup. Entries are measured results, withheld results pending publication-safe evidence, or compatibility findings. They are not vendor specifications or theoretical estimates.
 
-## Withheld pending publication-safe evidence
+## Withheld pending publication-safe evidence (no club-published claims)
 
 **Qwen3.8-27B W4A16 + DFlash2, three single-card runs:** a three-card result exists, but its current evidence revision contains prohibited infrastructure identifiers and requires an owner-approved history repair before a sanitized re-pin. Numbers and evidence links return here only after that repair.
 
@@ -12,7 +12,7 @@ Results here are application measurements on the tested CMP 170HX setup. They ar
 
 ### GLM-5.3-Flash (all quantizations)
 
-**Compatibility result, not a performance result.** As of the stable summary at [GLM-5.3-Flash-CMP-170HX @ `07b28e6`](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/07b28e6d8d3b9fe7cb8a69f37e36088ffa71cec8/README.md), no completed serving run has been published:
+**Compatibility result, not a performance result.** As of the stable summary at [GLM-5.3-Flash-CMP-170HX @ `58eece6`](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/58eece6db097fb1d5e0a767b752fd1c040b3ac58/README.md), no completed serving run has been published:
 
 - NVFP4 targets an SM121 runtime path — incompatible with SM80 (**measured** registry check). Upstream vLLM support ([PR 53906](https://github.com/vllm-project/vllm/pull/53906)) is open and SM90+.
 - AWQ INT4 is 198.1 GiB — over the 192 GiB three-card total before KV (**measured** blob sizes).

--- a/docs/COOLING-AND-POWER.md
+++ b/docs/COOLING-AND-POWER.md
@@ -2,6 +2,20 @@
 
 CMP 170HX cards are passive server accelerators. An open case and a room fan are not automatically enough: air must be forced through the heatsink fins, and exhaust must not recirculate into the intake.
 
+## Idle heat is real heat
+
+On 2026-08-30, after the build described in the [hardware guide](HARDWARE.md#our-four-card-rig) was finished, the four-card rig idled with a 180 W limit per card and the blower running:
+
+| Metric | Measured idle snapshot (n=1) |
+|---|---|
+| Core temperature | 37–38 °C |
+| Memory temperature | 41–51 °C |
+| Board power per card | 33.71–37.69 W |
+| Group power, four cards | about 141 W |
+| GPU utilization / VRAM used | 0% / 0 MiB on every card |
+
+This is one timestamped snapshot; check live values with the `nvidia-smi` query command under [practical policies](#practical-policies). Ambient temperature and blower RPM were not recorded, so treat these ranges as observations from this frame, not design limits. The plain lesson: four idle cards still turn roughly 141 W into heat, and one card's memory was already at 51 °C with no workload. An open frame alone does not cool these cards.
+
 ## Practical policies
 
 | Mode | Measured policy | Use |
@@ -21,6 +35,10 @@ nvidia-smi --query-gpu=index,power.draw,power.limit,temperature.gpu,temperature.
 ```
 
 An older service or startup script may overwrite the desired limit after boot. Always verify the live value rather than trusting a service's `active (exited)` state.
+
+## Workload peaks to compare against
+
+The single-card Qwen runs in the [benchmark registry](BENCHMARKS.md) give a reference point for what sustained load adds to these idle numbers. Those runs used a 180 W limit and peaked at 51 °C core and 61 °C memory; the evidence is pinned at [Qwen3.8-27B-CMP-170HX @ `41d2c41`](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md). Four-card load peaks are untested; do not extrapolate one-card thermals to the full rig.
 
 ## Temperature policy
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -27,6 +27,14 @@ Confirm these items first:
 
 Never mix modular PSU cables between PSU models, even when the connector fits. Keep each riser and its GPU power on a deliberate, documented power domain.
 
+## Our four-card rig
+
+The current test rig holds four CMP 170HX cards in an open-frame chassis with enough spacing between slots to reach every power connector. Each card gets its own cable; there are no splitters. Cables are dressed to the frame so they cannot sag into neighboring fans or block a heatsink face.
+
+Because the cards are passive, the frame depends on one 80 mm blower pushing air through a 3D-printed duct seated over the heatsink inlet at one end of the stack. The duct feeds the fin channels; air enters at the ducted end and exhausts out the opposite side of the frame, so keep a clear lane at both ends. Don't crowd either side; these cards heat quickly when airflow stalls.
+
+The blower speed is fixed; the cards provide no fan-speed control, so treat the blower as always-on hardware rather than something the driver manages. Its RPM is unmeasured and ambient temperature was not recorded during the idle snapshots below, which is one reason these numbers describe this frame and not a product.
+
 ## First inventory
 
 With no workload running:


### PR DESCRIPTION
## Summary

- Refresh the README four-card section with the 2026-08-30 idle snapshot from the current build.
- Add an "Our four-card rig" section to the hardware guide.
- Expand the cooling guide with the idle snapshot table and preserve the existing thermal stop policy.

Stacked on public PR #4. Evidence comes from the internal measurement record plus public benchmark documentation. No new measurements were taken and no GPU was used.
