### PR TITLE
docs: add four-card cooling note

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The CMP 170HX shares useful traits with A100-class hardware, including SM80 comp
 
 I traded out three RTX 3090s and rebuilt this node around four CMP 170HXs. The reason was simple: the four cards expose 256 GiB of aggregate HBM in one box. The lab still has RTX 3090 cards and DGX Spark systems, giving us useful comparison points for consumer CUDA, low-cost SM80/HBM, and GB10. DGX Spark notes live in [club-dgx-spark](https://github.com/PixelML/club-dgx-spark).
 
-**Measured on 2026-08-30:** all four cards enumerated in one Ubuntu guest with driver 610.43.03 and reported 65,536 MiB each. With a 180 W cap, the idle snapshot showed 31–32 °C core temperatures, 35–45 °C memory temperatures, 32–36 W per card, zero memory use, and zero GPU utilization. This is a bring-up result, not a four-card performance benchmark.
+**Measured on 2026-08-30:** all four cards enumerated in one Ubuntu guest with driver 610.43.03 and reported 65,536 MiB each. This is a bring-up inventory, not a four-card performance benchmark. Under the current build (four cards in an open frame with one 80 mm blower on a printed duct), a later idle snapshot the same day showed 37–38 °C cores, 41–51 °C memory temperatures, and about 141 W for the group at zero utilization. Cooling and power details are in [Cooling and power](docs/COOLING-AND-POWER.md).
 
 ## Verified baseline
 

--- a/docs/COOLING-AND-POWER.md
+++ b/docs/COOLING-AND-POWER.md
@@ -2,6 +2,20 @@
 
 CMP 170HX cards are passive server accelerators. An open case and a room fan are not automatically enough: air must be forced through the heatsink fins, and exhaust must not recirculate into the intake.
 
+## Idle heat is real heat
+
+On 2026-08-30, after the build described in the [hardware guide](HARDWARE.md#our-four-card-rig) was finished, the four-card rig idled with a 180 W limit per card and the blower running:
+
+| Metric | Measured idle snapshot (n=1) |
+|---|---|
+| Core temperature | 37–38 °C |
+| Memory temperature | 41–51 °C |
+| Board power per card | 33.71–37.69 W |
+| Group power, four cards | about 141 W |
+| GPU utilization / VRAM used | 0% / 0 MiB on every card |
+
+This is one timestamped snapshot; check live values with the `nvidia-smi` query command under [practical policies](#practical-policies). Ambient temperature and blower RPM were not recorded, so treat these ranges as observations from this frame, not design limits. The plain lesson: four idle cards still turn roughly 141 W into heat, and one card's memory was already at 51 °C with no workload. An open frame alone does not cool these cards.
+
 ## Practical policies
 
 | Mode | Measured policy | Use |
@@ -21,6 +35,10 @@ nvidia-smi --query-gpu=index,power.draw,power.limit,temperature.gpu,temperature.
 ```
 
 An older service or startup script may overwrite the desired limit after boot. Always verify the live value rather than trusting a service's `active (exited)` state.
+
+## Workload peaks to compare against
+
+The single-card Qwen runs in the [benchmark registry](BENCHMARKS.md) give a reference point for what sustained load adds to these idle numbers. Those runs used a 180 W limit and peaked at 51 °C core and 61 °C memory; the evidence is pinned at [Qwen3.8-27B-CMP-170HX @ `41d2c41`](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md). Four-card load peaks are untested; do not extrapolate one-card thermals to the full rig.
 
 ## Temperature policy
 

--- a/docs/COOLING-AND-POWER.md
+++ b/docs/COOLING-AND-POWER.md
@@ -38,7 +38,7 @@ An older service or startup script may overwrite the desired limit after boot. A
 
 ## Workload peaks to compare against
 
-The single-card Qwen runs in the [benchmark registry](BENCHMARKS.md) give a reference point for what sustained load adds to these idle numbers. Those runs used a 180 W limit and peaked at 51 °C core and 61 °C memory; the evidence is pinned at [Qwen3.8-27B-CMP-170HX @ `41d2c41`](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/blob/41d2c414fe0f293d77087ef18cda5896664754d6/RESULTS.md). Four-card load peaks are untested; do not extrapolate one-card thermals to the full rig.
+Sustained single-card load peaks are known from club measurements, but that evidence revision contains prohibited infrastructure identifiers, so the numbers and their links are withheld here pending the owner-approved history repair and sanitized re-pin already tracked in the benchmark registry. Four-card load peaks are untested; do not extrapolate one-card thermals to the full rig. Once a sanitized Qwen pin lands, this section gets the measured core/memory peaks back.
 
 ## Temperature policy
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -33,7 +33,7 @@ The current test rig holds four CMP 170HX cards in an open-frame chassis with en
 
 Because the cards are passive, the frame depends on one 80 mm blower pushing air through a 3D-printed duct seated over the heatsink inlet at one end of the stack. The duct feeds the fin channels; air enters at the ducted end and exhausts out the opposite side of the frame, so keep a clear lane at both ends. Don't crowd either side; these cards heat quickly when airflow stalls.
 
-The blower speed is fixed; the cards provide no fan-speed control, so treat the blower as always-on hardware rather than something the driver manages. Its RPM is unmeasured and ambient temperature was not recorded during the idle snapshots below, which is one reason these numbers describe this frame and not a product.
+The blower speed is fixed; the cards provide no fan-speed control, so treat the blower as always-on hardware rather than something the driver manages. Its RPM is unmeasured and ambient temperature was not recorded during the current idle snapshot, which is one reason these numbers describe this frame and not a product.
 
 ## First inventory
 
@@ -49,7 +49,9 @@ Save a redacted baseline outside the public repository. A card missing from `lsp
 
 ## Known-good measured configuration
 
-**Measured inventory:** four cards enumerated in one Ubuntu guest on 2026-08-30 and exposed 65,536 MiB each, for 256 GiB aggregate. At idle with a 180 W cap, all four reported 31–32 °C core temperatures, 35–45 °C memory temperatures, 32–36 W power draw, and 0% GPU utilization. Four-card workload performance remains untested.
+**Measured inventory:** four cards enumerated in one Ubuntu guest on 2026-08-30 and exposed 65,536 MiB each, for 256 GiB aggregate. Four-card workload performance remains untested.
+
+**Earlier bring-up snapshot (pre-duct arrangement):** at idle with a 180 W cap during initial bring-up, before the current open-frame duct described above was in place, the four cards reported 31–32 °C core temperatures, 35–45 °C memory temperatures, 32–36 W per card, and 0% GPU utilization. This is a different setup state and a different measurement from the current rig; do not blend the ranges. The current-arrangement idle table lives in [Cooling and power](COOLING-AND-POWER.md#idle-heat-is-real-heat).
 
 **Measured:** three cards passed CUDA enumeration, a 16 GiB cross-window write/read smoke test, an SM kernel, and post-load health checks under Ubuntu 22.04, Linux 6.8, driver 610.43.03, and the pinned unlocker described in [Installation](INSTALLATION.md).
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -27,6 +27,14 @@ Confirm these items first:
 
 Never mix modular PSU cables between PSU models, even when the connector fits. Keep each riser and its GPU power on a deliberate, documented power domain.
 
+## Our four-card rig
+
+The current test rig holds four CMP 170HX cards in an open-frame chassis with enough spacing between slots to reach every power connector. Each card gets its own cable; there are no splitters. Cables are dressed to the frame so they cannot sag into neighboring fans or block a heatsink face.
+
+Because the cards are passive, the frame depends on one 80 mm blower pushing air through a 3D-printed duct seated over the heatsink inlet at one end of the stack. The duct feeds the fin channels; air enters at the ducted end and exhausts out the opposite side of the frame, so keep a clear lane at both ends. Don't crowd either side; these cards heat quickly when airflow stalls.
+
+The blower speed is fixed; the cards provide no fan-speed control, so treat the blower as always-on hardware rather than something the driver manages. Its RPM is unmeasured and ambient temperature was not recorded during the idle snapshots below, which is one reason these numbers describe this frame and not a product.
+
 ## First inventory
 
 With no workload running:


### PR DESCRIPTION
## Summary

- Refresh the README four-card section with the 2026-08-30 idle snapshot from the current build.
- Add an "Our four-card rig" section to the hardware guide.
- Expand the cooling guide with the idle snapshot table while withholding workload peaks until sanitized public evidence is merged.

Addresses both findings from the independent exact-head review of public PR #7. Branch history contains only the three-file hardware/cooling delta. Evidence comes from the internal measurement record; no new measurements were taken and no GPU was used.
