### PR TITLE
results: GLM-5.3-Flash UD-IQ4_XS llama.cpp baseline on 4x CMP 170HX

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 ## Published workload results
 
-| Workload | Topology | Result | Evidence |
-|---|---:|---:|---|
-| Qwen3.8-27B NVFP4 | 1 card | 136.38 tok/s mean at 180 W across three cards | [Benchmark repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
-| DeepSeek-V4-Flash-0731 | 3 cards, pipeline parallel | 83.3 tok/s aggregate decode at 180 W/card | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
-| GLM-5.3-Flash UD-IQ4_XS (llama.cpp) | 4 cards | 17.73 tok/s decode median at c=1 (5 reps after 3 warmups); ~17.5–17.7 tok/s aggregate at c=2/4; 41/41 soak reps; local quality 21/26 (telemetry: end-of-run snapshot only; energy not integrated) | [Result file](results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md) · [Evidence pin](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/7fc71e00925f7b7902764aab7d08b6d923aaaea4/results/phase63/run-manifest.json) |
+Canonical scoreboard of publication-safe PixelML measurements on CMP 170HX. Normalized metric matrix, methodology, and evidence tiers: [docs/BENCHMARKS.md](docs/BENCHMARKS.md). Raw manifests and receipts stay in the model repositories.
 
-These are measured application results, not theoretical peaks. The linked repositories contain commands, model/runtime pins, per-run outputs, and known caveats.
+| Workload | Quant / runtime | Topology | Decode | Aggregate | Quality / success | Status | Evidence |
+|---|---|---|---|---|---|---|---|
+| GLM-5.3-Flash | UD-IQ4_XS · llama.cpp | 4 cards · layer split · 16k ctx · c ≤ 4 | 17.73 tok/s median @ c=1 | ~17.5–17.7 tok/s @ c=2/4 | 21/26 local tasks · 41/41 soak | Publication-safe | [Result card](results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md) · [Evidence pin](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/7fc71e00925f7b7902764aab7d08b6d923aaaea4/results/phase63/run-manifest.json) |
+| GLM-5.3-Flash | NVFP4 | 3 cards | — | — | — | Not compatible: SM121-format weights on SM80; AWQ INT4 ≈ 66 GiB/card does not fit 3 × 64 GiB | [Negative result](docs/BENCHMARKS.md#negative-results-matter) |
+| Qwen3.8-27B | NVFP4 · vLLM | 1 card × 3 runs @ 180 W | — | — | — | Pending evidence repair: [#58](https://github.com/seanphan/pixelml/issues/58) · [repo PR 1](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
+| DeepSeek-V4-Flash-0731 | FP8 · vLLM pipeline | 3 cards | — | — | — | Pending evidence repair: [#65](https://github.com/seanphan/pixelml/issues/65) · [repo PR 1](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
+
+`—` = not presented without sanitized stable evidence. Pending rows are not decision-grade; owning tickets repair the evidence, then the rows are restored.
 
 ## Repository map
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 |---|---:|---:|---|
 | Qwen3.8-27B NVFP4 | 1 card | 136.38 tok/s mean at 180 W across three cards | [Benchmark repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
 | DeepSeek-V4-Flash-0731 | 3 cards, pipeline parallel | 83.3 tok/s aggregate decode at 180 W/card | [Benchmark repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
-| GLM-5.3-Flash NVFP4 | 3 cards | Not compatible: SM121-format weights and runtime path | [Compatibility notes](docs/BENCHMARKS.md#negative-results-matter) |
+| GLM-5.3-Flash UD-IQ4_XS (llama.cpp) | 4 cards | 17.73 tok/s decode median at c=1 (5 reps after 3 warmups); ~17.5–17.7 tok/s aggregate at c=2/4; 41/41 soak reps; local quality 21/26 (telemetry: end-of-run snapshot only; energy not integrated) | [Result file](results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md) · [Evidence pin](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/7fc71e00925f7b7902764aab7d08b6d923aaaea4/results/phase63/run-manifest.json) |
 
 These are measured application results, not theoretical peaks. The linked repositories contain commands, model/runtime pins, per-run outputs, and known caveats.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,10 +1,47 @@
 # Benchmarks
 
-Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates.
+Results here are application measurements on the tested CMP 170HX setup. They are not vendor specifications or theoretical estimates. This page is the normalized comparison index; raw manifests, commands, and receipts stay in the model repositories.
 
-## Qwen3.8-27B NVFP4, one card
+## Evidence tiers
 
-**Measured:** three separate CMP 170HX cards at a 180 W limit.
+A row is **publication-safe** only when the full sanitized receipt chain (manifest, commands, redacted outputs, exact model/runtime pins) is merged in the owning model repository. Rows whose receipts are unmerged are **pending evidence repair**: their owning tickets repair the evidence chain, and the numbers are not decision-grade until then. The README scoreboard mirrors these statuses.
+
+## Normalized matrix
+
+`—` = not presented without sanitized stable evidence. Do not interpolate or compare unlike metrics.
+
+| Workload | Quant / runtime | Cards | Context | Concurrency | Prefill | Decode | Aggregate | TTFT | ITL | Quality / success | Power / thermals | Energy | Status | Evidence |
+|---|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---|---|
+| GLM-5.3-Flash | UD-IQ4_XS · llama.cpp (0069971) | 4 · layer split | 16,384 | c=1; ladder 1/2/4; soak c=2 | — | 17.73 tok/s median (c=1) | ~17.5–17.7 tok/s (c=2/4) | — | — | 21/26 local tasks · 41/41 soak reps | Snapshot only: 40.10–44.49 W, core 41–43 °C, mem 45–55 °C, VRAM 32,656–42,312 / 65,536 MiB; limit not queried | Snapshot proxy only, not integrated | Publication-safe | [Run manifest](https://github.com/PixelML/GLM-5.3-Flash-CMP-170HX/blob/7fc71e00925f7b7902764aab7d08b6d923aaaea4/results/phase63/run-manifest.json) · [Result card](results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md) |
+| GLM-5.3-Flash | NVFP4 | 3 | — | — | — | — | — | — | — | — | — | — | Not compatible (SM121 weights on SM80) | [Negative results](#negative-results-matter) |
+| Qwen3.8-27B | NVFP4 · vLLM | 1 (× 3 runs) | — | — | — | — | — | — | — | — | — | — | Pending evidence repair · [#58](https://github.com/seanphan/pixelml/issues/58) · [repo PR 1](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
+| DeepSeek-V4-Flash-0731 | FP8 · vLLM pipeline | 3 | 16,384 | — | — | — | — | — | — | — | — | — | Pending evidence repair · [#65](https://github.com/seanphan/pixelml/issues/65) · [repo PR 1](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
+
+## GLM-5.3-Flash UD-IQ4_XS, four cards (publication-safe)
+
+**Measured:** 4 × 64 GiB CMP 170HX, layer split (`--tensor-split 1,1,1,1`), 16,384 context, unslothai/llama.cpp at commit 00699716c275498ff84d71e329178fe21cba56a6, driver 610.43.03, kernel 6.8, Ubuntu 22.04. Model: unsloth/GLM-5.3-Flash-GGUF at revision 2975ab414d30340466d8c51533c6e91f0cca64c1, 5-shard UD-IQ4_XS (~146 GiB).
+
+| Metric | Value |
+|---|---:|
+| Decode, c=1 median (5 reps after 3 warmups) | 17.73 tok/s |
+| End-to-end per task, c=1 | 14.44 s |
+| Aggregate, c=2 and c=4 ladder (2 reps each) | ~17.5–17.7 tok/s (flat) |
+| Soak, 20 min at c=2 | 41/41 reps ok, stable 17.5→17.7 tok/s |
+| Quality, corrected 26-task pack | 21/26 (math 8/8, instruction 4/5, long-context 3/3, held-out math 4/4, held-out code 1/1, coding 1/3, held-out instruction 0/2) |
+| Prefill / TTFT / ITL | — (not captured in sanitized receipts) |
+| Power, end-of-run snapshot per card | 40.10 / 44.49 / 40.64 / 41.82 W (configured limit not queried) |
+| Temperatures, end-of-run snapshot | core 41–43 °C, memory 45–55 °C (continuous/peak not recorded) |
+| VRAM, end-of-run snapshot per card | 32,656–42,312 of 65,536 MiB |
+| Energy | single-snapshot power proxy; not integrated energy and not a lower bound |
+| Fault telemetry | continuous throttle/Xid/thermal telemetry not recorded this run; no fault-free-operation claim is made |
+
+Aggregate curve flatness beyond c=4 and at longer contexts is untested. Result card: [results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md](results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md).
+
+## Qwen3.8-27B NVFP4, one card — pending evidence repair
+
+**Status:** the canonical sanitized receipts for the three-card runs are unmerged ([repo PR 1](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/pull/1); owning ticket [#58](https://github.com/seanphan/pixelml/issues/58)). The numbers below are platform context, not decision-grade, until that repair lands.
+
+**Measured (context):** three separate CMP 170HX cards at a 180 W limit.
 
 | Card | Decode, 256 output tokens | Decode, 900 output tokens | TTFT | Prefill |
 |---|---:|---:|---:|---:|
@@ -17,9 +54,11 @@ Peak observed core temperature was 51 °C; peak observed memory temperature acro
 
 Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX).
 
-## DeepSeek-V4-Flash-0731, three cards
+## DeepSeek-V4-Flash-0731, three cards — pending evidence repair
 
-**Measured:** 3 × 64 GiB cards, pipeline parallel size 3, 180 W/card, FP8 KV cache, 16,384 maximum sequence length, and speculative decoding with `k=5`.
+**Status:** canonical sanitized receipts are unmerged ([repo PR 1](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/pull/1); owning ticket [#65](https://github.com/seanphan/pixelml/issues/65)). Numbers below are platform context until the repair lands.
+
+**Measured (context):** 3 × 64 GiB cards, pipeline parallel size 3, 180 W/card, FP8 KV cache, 16,384 maximum sequence length, and speculative decoding with `k=5`.
 
 | Prompt class | Decode throughput |
 |---|---:|
@@ -51,5 +90,7 @@ Every submitted result must include:
 - raw redacted output and an explanation of the metric calculation.
 
 For server-sent-event APIs, count generated tokens from the final `usage.completion_tokens`. Counting stream events produced incorrect results in an earlier harness because events are not tokens.
+
+Rows marked `pending evidence repair` are restored to full decision-grade status only when the owning model repository merges the sanitized receipt chain, and the README scoreboard is updated in the same workflow.
 
 Use the template in [results/README.md](../results/README.md).

--- a/results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md
+++ b/results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md
@@ -7,8 +7,8 @@ Date: 2026-08-30
 
 - Cards: 4 × CMP 170HX (64 GiB HBM2e each)
 - Anonymous card labels: four cards, homogeneous, even tensor split
-- Power limit and measured peak draw: stock limit; 40–70 W measured during load
-- Cooling and peak core/memory temperatures: forced airflow; 40–43 °C core, 45–56 °C memory
+- Power draw and limit: per-card power captured in an end-of-run snapshot only (40.10–44.49 W); the configured power limit was not queried this phase
+- Cooling and temperatures: forced airflow; end-of-run snapshot 41–43 °C core, 45–55 °C memory (continuous/peak telemetry not recorded this phase)
 
 ## Software
 
@@ -16,12 +16,14 @@ Date: 2026-08-30
 - NVIDIA driver / CUDA: driver 610.43.03 (CUDA toolkit version not runtime-pinned in this run)
 - Runtime repository + exact commit: unslothai/llama.cpp fork at commit 00699716c275498ff84d71e329178fe21cba56a6, built with CUDA for compute capability 8.0
 - Model repository + exact revision: unsloth/GLM-5.3-Flash-GGUF at revision 2975ab414d30340466d8c51533c6e91f0cca64c1 (UD-IQ4_XS, 5-shard GGUF, per-shard SHA-256 verified)
-- Quantization / dtype: IQ4_XS variant (UD), ~146 GiB on disk, ~33–42 GiB per card at 4-way split
+- Quantization / dtype: IQ4_XS variant (UD), ~146 GiB on disk; end-of-run VRAM snapshot 32,656–42,312 MiB of 65,536 MiB per card at 4-way split
 
 ## Command
 
+Exact serve configuration from the run manifest (`--batch 2048`, `--ubatch 512`, and flash attention were server defaults in this build):
+
 ```text
-llama-server --model <5-shard GGUF, first shard path> --tensor-split 1,1,1,1 --ctx-size 16384 --batch 2048 --ubatch 512 --port <port> --host 127.0.0.1
+llama-server --model <5-shard GGUF, first shard path> --split-mode layer --tensor-split 1,1,1,1 --ctx-size 16384 --parallel 1 --threads 8 --port <port> --host 127.0.0.1
 ```
 
 ## Method
@@ -37,25 +39,24 @@ llama-server --model <5-shard GGUF, first shard path> --tensor-split 1,1,1,1 --c
 |---|---:|
 | Decode throughput, c=1 median | 17.73 tok/s |
 | End-to-end per task, c=1 | 14.44 s |
-| Aggregate at c=2 and c=4 | ~17.5–17.7 tok/s (compute-bound, flat) |
+| Aggregate at c=2 and c=4 | ~17.5–17.7 tok/s (flat) |
 | Soak (20 min, c=2) | 41/41 reps ok, stable 17.5→17.7 tok/s |
 | Corrected 26-task quality | 21/26 (math 8/8, instruction 4/5, long-context 3/3, held-out math 4/4, held-out code 1/1, coding 1/3, held-out instruction 0/2) |
-| Throttle events | 0 |
 
 Measured notes:
 
-- Throughput is flat from c=1 to c=4 (compute-bound); the card count is not the bottleneck at this context and quant.
 - Two harness defects were found and fixed during measurement (a sandbox wrapper that dropped the candidate module, and completion budgets that starved reasoning output); the remaining quality misses are model-output behavior, verified by direct probes.
 
 ## Correctness and failures
 
 - Output validation: all benchmark requests completed with valid usage objects; quality tasks scored deterministically
-- Xid/ECC/AER scan: no Xid, no throttling across the phase including the 20-minute soak
-- Known caveats: single-run, small-sample quality gate (not a leaderboard); energy figures are GPU-only lower bounds with a disclosed hypothetical price band; coding-task misses trace to reasoning-length truncation at a 2048-token ceiling, so larger budgets may score higher
+- Telemetry coverage: end-of-run snapshot only; continuous throttle, Xid, and thermal telemetry was not recorded during the run, so no fault-free-operation claim is made (known gap; the updated rebench harness records it for future runs)
+- Energy: a single end-of-run power reading times task duration is a snapshot proxy — not integrated energy and not a lower bound; power/energy figures are indicative only
+- Known caveats: single-run, small-sample quality gate (not a leaderboard)
 
 ## Evidence
 
-- Raw redacted receipts, corrected quality pack, charts, and harness: PixelML/GLM-5.3-Flash-CMP-170HX PR #3 (branch pr3-clean, single-commit review head)
-- Phase C terminal receipt: seanphan/pixelml issue #63, comment 5471362490
+- Raw redacted receipts, corrected quality pack, charts, and harness: PixelML/GLM-5.3-Flash-CMP-170HX PR #7 at head 7fc71e00925f7b7902764aab7d08b6d923aaaea4 (run-manifest pin 84b62bf0b21d6590e34cba9d87df3b8d5c5a84fb)
+- Reproduction: rebench harness and one-command re-run documented in that repository under `bench/`
 
-Inferred (not measured): the flat concurrency curve suggests headroom for longer contexts before compute saturation; untested here.
+Inferred (not measured): the flat aggregate curve is consistent with compute saturation at this context and quant; behavior beyond c=4 and at longer contexts is untested here.

--- a/results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md
+++ b/results/2026-08-30-glm-5.3-flash-ud-iq4xs-llamacpp-cmp170hx.md
@@ -1,0 +1,61 @@
+# Workload — GLM-5.3-Flash UD-IQ4_XS on llama.cpp (llama-server), 4 × CMP 170HX
+
+Status: measured
+Date: 2026-08-30
+
+## Hardware
+
+- Cards: 4 × CMP 170HX (64 GiB HBM2e each)
+- Anonymous card labels: four cards, homogeneous, even tensor split
+- Power limit and measured peak draw: stock limit; 40–70 W measured during load
+- Cooling and peak core/memory temperatures: forced airflow; 40–43 °C core, 45–56 °C memory
+
+## Software
+
+- OS / kernel: Ubuntu 22.04, kernel 6.8 (measured on the host under test)
+- NVIDIA driver / CUDA: driver 610.43.03 (CUDA toolkit version not runtime-pinned in this run)
+- Runtime repository + exact commit: unslothai/llama.cpp fork at commit 00699716c275498ff84d71e329178fe21cba56a6, built with CUDA for compute capability 8.0
+- Model repository + exact revision: unsloth/GLM-5.3-Flash-GGUF at revision 2975ab414d30340466d8c51533c6e91f0cca64c1 (UD-IQ4_XS, 5-shard GGUF, per-shard SHA-256 verified)
+- Quantization / dtype: IQ4_XS variant (UD), ~146 GiB on disk, ~33–42 GiB per card at 4-way split
+
+## Command
+
+```text
+llama-server --model <5-shard GGUF, first shard path> --tensor-split 1,1,1,1 --ctx-size 16384 --batch 2048 --ubatch 512 --port <port> --host 127.0.0.1
+```
+
+## Method
+
+- Warmup: 3 discarded single-stream reps
+- Samples: 5 measured reps at concurrency 1 (400-token prompt / 256-token completion); concurrency ladder 1/2/4 × 2 reps; 41-rep soak at concurrency 2 over 20 minutes; medians reported
+- Input/output tokens: 400 in / 256 out per request; tokens derived from the final usage object
+- Metric calculation: aggregate tok/s = completion tokens / wall time; per-request tok/s from usage; quality = 26 deterministic local tasks (exact-match math, constraint instruction-following, needle-in-haystack long context, sandboxed code execution)
+
+## Results
+
+| Metric | Value |
+|---|---:|
+| Decode throughput, c=1 median | 17.73 tok/s |
+| End-to-end per task, c=1 | 14.44 s |
+| Aggregate at c=2 and c=4 | ~17.5–17.7 tok/s (compute-bound, flat) |
+| Soak (20 min, c=2) | 41/41 reps ok, stable 17.5→17.7 tok/s |
+| Corrected 26-task quality | 21/26 (math 8/8, instruction 4/5, long-context 3/3, held-out math 4/4, held-out code 1/1, coding 1/3, held-out instruction 0/2) |
+| Throttle events | 0 |
+
+Measured notes:
+
+- Throughput is flat from c=1 to c=4 (compute-bound); the card count is not the bottleneck at this context and quant.
+- Two harness defects were found and fixed during measurement (a sandbox wrapper that dropped the candidate module, and completion budgets that starved reasoning output); the remaining quality misses are model-output behavior, verified by direct probes.
+
+## Correctness and failures
+
+- Output validation: all benchmark requests completed with valid usage objects; quality tasks scored deterministically
+- Xid/ECC/AER scan: no Xid, no throttling across the phase including the 20-minute soak
+- Known caveats: single-run, small-sample quality gate (not a leaderboard); energy figures are GPU-only lower bounds with a disclosed hypothetical price band; coding-task misses trace to reasoning-length truncation at a 2048-token ceiling, so larger budgets may score higher
+
+## Evidence
+
+- Raw redacted receipts, corrected quality pack, charts, and harness: PixelML/GLM-5.3-Flash-CMP-170HX PR #3 (branch pr3-clean, single-commit review head)
+- Phase C terminal receipt: seanphan/pixelml issue #63, comment 5471362490
+
+Inferred (not measured): the flat concurrency curve suggests headroom for longer contexts before compute saturation; untested here.


### PR DESCRIPTION
Reusable platform findings from the GLM track, submitted per the results template. Measured (full detail in the file): 17.73 tok/s c=1 median on a 5-rep protocol task; flat aggregate throughput 1→4 concurrency; 41-rep soak at c=2 completed 41/41; corrected 26-task local quality 21/26.

Telemetry was an end-of-run snapshot only: continuous throttle/Xid/thermal telemetry is a known gap of this run, so no fault-free-operation claim is made. Energy is a snapshot power proxy, not integrated energy and not a lower bound.

Evidence: PixelML/GLM-5.3-Flash-CMP-170HX PR #7 at head 7fc71e00925f7b7902764aab7d08b6d923aaaea4 (run-manifest pin 84b62bf0b21d6590e34cba9d87df3b8d5c5a84fb). Sanitization gate clean. Ready for exact-head review.
