### PR TITLE
docs: publish provisional DeepSeek vision baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ Exact versions matter. Treat this as a known-good reference, not a claim that ev
 
 ## Published workload results
 
-Canonical scoreboard of publication-safe PixelML measurements on CMP 170HX. Normalized metric matrix, methodology, and evidence tiers: [docs/BENCHMARKS.md](docs/BENCHMARKS.md). Raw manifests and receipts stay in the model repositories.
+Canonical scoreboard of PixelML measurements on CMP 170HX. The status column
+separates publication-safe results from provisional or blocked measurements.
+Normalized metrics, methodology, and evidence tiers:
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md). Raw manifests and receipts stay in
+the model repositories; small redacted snapshots may be retained here when the
+detailed ledger is not public.
 
 | Workload | Quant / runtime | Topology | Decode | Aggregate | Quality / success | Status | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -57,8 +62,15 @@ Canonical scoreboard of publication-safe PixelML measurements on CMP 170HX. Norm
 | GLM-5.3-Flash | NVFP4 | 3 cards | — | — | — | Not compatible: SM121-format weights on SM80; AWQ INT4 ≈ 66 GiB/card does not fit 3 × 64 GiB | [Negative result](docs/BENCHMARKS.md#negative-results-matter) |
 | Qwen3.8-27B | NVFP4 · vLLM | 1 card × 3 runs @ 180 W | — | — | — | Pending evidence repair: [repo PR 1](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
 | DeepSeek-V4-Flash-0731 | FP8 · vLLM pipeline | 3 cards | — | — | — | Pending evidence repair: [repo PR 1](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
+| DeepSeek-V4-Flash-Vision-Exp | FP8 · SM80 vLLM fork | 4 cards · PP4 | **59.78 tok/s warm** · 56.6 sustained | **169.65 tok/s @ c=4** · 325.5 tok/s prefill | Text passed; image rejected (HTTP 400) | Provisional measured text baseline; vision and immutable runtime pin still blocked | [Result summary](results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.md) |
 
-`—` = not presented without sanitized stable evidence. Pending rows are not decision-grade; owning tickets repair the evidence, then the rows are restored.
+`—` = not presented without sanitized stable evidence. Pending and provisional
+rows are not decision-grade; they remain visible so measured learning is not
+lost, but their status and blockers must stay explicit.
+
+The Vision-Exp row is intentionally visible but not labeled publication-safe:
+the key text numbers are measured, while the SM80 runtime does not yet wire the
+vision tower and its source revision was unavailable from the measured image.
 
 ## Repository map
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,6 +16,7 @@ A row is **publication-safe** only when the full sanitized receipt chain (manife
 | GLM-5.3-Flash | NVFP4 | 3 | — | — | — | — | — | — | — | — | — | — | Not compatible (SM121 weights on SM80) | [Negative results](#negative-results-matter) |
 | Qwen3.8-27B | NVFP4 · vLLM | 1 (× 3 runs) | — | — | — | — | — | — | — | — | — | — | Pending evidence repair · [repo PR 1](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX) |
 | DeepSeek-V4-Flash-0731 | FP8 · vLLM pipeline | 3 | 16,384 | — | — | — | — | — | — | — | — | — | Pending evidence repair · [repo PR 1](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX/pull/1) | [Repo](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX) |
+| DeepSeek-V4-Flash-Vision-Exp | FP8 · SM80 vLLM fork | 4 · PP4 | 16,384 | c=1; ladder 1/2/4/8 | 325.5 tok/s (2,941 input tokens) | 59.78 tok/s warm; 56.6 tok/s sustained | 169.65 tok/s @ c=4 | 0.163 s warm | — | Text passed; image rejected (HTTP 400) | Loaded sample: 114–137 W/card peak, core ≤46 °C, no throttle flags | — | Provisional measured text baseline; vision unavailable and runtime source revision unpinned | [Summary](../results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.md) · [Redacted data](../results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.json) |
 
 ## GLM-5.3-Flash UD-IQ4_XS, four cards (publication-safe)
 
@@ -70,6 +71,35 @@ Reproduction and raw outputs: [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com
 Measured prefill reached 2,965 tok/s at 5,399 input tokens. Draft-token acceptance ranged from 5.07 to 5.32 tokens, or roughly 81–86%. The 48-shard checkpoint was about 148 GB. Cold startup included approximately 22 minutes of weight loading from shared storage plus approximately seven minutes of CUDA graph capture.
 
 The precompiled runtime image lacked `vllm._C` for this path; a source build was required. Full details: [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX).
+
+## DeepSeek-V4-Flash-Vision-Exp, four cards — provisional text baseline
+
+**Status:** the text path is measured, but this is not a publication-safe
+multimodal recipe. The measured SM80 runtime rejected image input, and its
+source revision was unavailable from the running image. The result stays
+provisional until vision passes and the runtime is immutably pinned.
+
+**Measured:** 4 × 64 GiB CMP 170HX, pipeline parallel size 4 with layer
+partition `11,11,11,10`, 16,384 maximum model length, FP8 KV cache, and
+DSpark speculative decoding with `k=6`. Model revision:
+`86f746b36186f0e567729a5c06a8c918caba82a9`.
+
+| Metric | Value |
+|---|---:|
+| Warm single-stream decode | **59.78 tok/s** |
+| Sustained decode, 800 completion tokens | **56.6 tok/s** |
+| Uncached prefill, 2,941 input tokens | **325.5 tok/s** |
+| Warm TTFT | **0.163 s** |
+| Aggregate decode, c=1 / 2 / 4 / 8 | 101.21 / 114.68 / **169.65** / 133.95 tok/s |
+| Image request | Rejected, HTTP 400 |
+
+Concurrency 4 was the stable throughput peak in the measured ladder. The
+concurrency-16 attempt wedged in the speculative draft path; it is outside the
+published stable envelope. The vision failure is a runtime compatibility gate,
+not evidence that the checkpoint itself is text-only.
+
+Public redacted snapshot: [result summary](../results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.md)
+and [structured data](../results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.json).
 
 ## Negative results matter
 

--- a/results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.json
+++ b/results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "status": "measured-provisional",
+  "publication_status": "blocked",
+  "date": "2026-08-31",
+  "model": {
+    "id": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+    "revision": "86f746b36186f0e567729a5c06a8c918caba82a9",
+    "format": "FP8 e4m3 weights, dynamic activations, 128x128 blocks"
+  },
+  "runtime": {
+    "engine": "source-built SM80 vLLM fork",
+    "source_revision": null,
+    "image_content_digest": "sha256:0e33b051516583ac8f9d2449a5d9889cadad8e43c121cc454d597c251986ddbe"
+  },
+  "hardware": {
+    "platform": "CMP 170HX",
+    "accelerator_count": 4,
+    "memory_gib_per_accelerator": 64,
+    "compute_capability": "8.0"
+  },
+  "recipe": {
+    "pipeline_parallel": 4,
+    "layer_partition": [11, 11, 11, 10],
+    "max_model_len": 16384,
+    "max_num_batched_tokens": 2048,
+    "max_num_seqs": 8,
+    "kv_cache_dtype": "fp8",
+    "speculative_method": "dspark",
+    "speculative_tokens": 6
+  },
+  "measurements": {
+    "cold_decode_tok_s": 51.06,
+    "warm_decode_tok_s": 59.78,
+    "sustained_decode": {
+      "prompt_tokens": 37,
+      "completion_tokens": 800,
+      "elapsed_s": 14.133,
+      "tok_s": 56.6
+    },
+    "cold_ttft_s": 0.214,
+    "warm_ttft_s": 0.163,
+    "uncached_prefill": {
+      "prompt_tokens": 2941,
+      "completion_tokens": 1,
+      "elapsed_s": 9.037,
+      "tok_s": 325.5
+    },
+    "concurrency_ladder": [
+      {"concurrency": 1, "completion_tokens": 400, "wall_s": 3.952, "aggregate_tok_s": 101.21},
+      {"concurrency": 2, "completion_tokens": 800, "wall_s": 6.976, "aggregate_tok_s": 114.68},
+      {"concurrency": 4, "completion_tokens": 1600, "wall_s": 9.431, "aggregate_tok_s": 169.65},
+      {"concurrency": 8, "completion_tokens": 3200, "wall_s": 23.889, "aggregate_tok_s": 133.95}
+    ]
+  },
+  "vision_gate": {
+    "status": "rejected",
+    "http_status": 400,
+    "classification": "tested SM80 runtime did not wire the vision tower"
+  },
+  "telemetry": {
+    "per_card_power_w_peak": [114.07, 105.17, 120.26, 136.77],
+    "core_temperature_c_max": 46,
+    "throttle_flags": "none observed"
+  },
+  "stable_envelope": {
+    "highest_measured_concurrency": 8,
+    "best_aggregate_concurrency": 4,
+    "excluded": [
+      {"concurrency": 16, "reason": "speculative draft-path wedge"}
+    ]
+  },
+  "blockers": [
+    "vision request failed on the tested runtime",
+    "runtime source revision was unavailable from the measured image",
+    "task-quality evaluation was not captured"
+  ]
+}

--- a/results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.md
+++ b/results/2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.md
@@ -1,0 +1,70 @@
+# DeepSeek-V4-Flash-Vision-Exp — provisional text baseline
+
+Status: measured, provisional
+Date: 2026-08-31
+
+The four-card text path reached **59.78 tok/s warm decode**, **325.5 tok/s
+uncached prefill**, and **169.65 tok/s aggregate at concurrency 4**. The tested
+SM80 runtime rejected image input, so this is not yet a successful vision
+recipe.
+
+## Hardware
+
+- Cards: 4 × CMP 170HX, 64 GiB each
+- Topology: pipeline parallel 4, layer partition `11,11,11,10`
+- Loaded telemetry sample: 114–137 W per-card peak; core temperature no higher
+  than 46 °C; no throttle flags
+- Configured power limit and integrated energy: not recorded in the public
+  snapshot
+
+## Software
+
+- Runtime: source-built SM80 vLLM fork
+- Runtime image content digest:
+  `sha256:0e33b051516583ac8f9d2449a5d9889cadad8e43c121cc454d597c251986ddbe`
+- Runtime source revision: unavailable from the measured image; this blocks a
+  publication-safe recipe
+- Model: `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`
+- Model revision: `86f746b36186f0e567729a5c06a8c918caba82a9`
+- Checkpoint format: FP8 e4m3 weights with dynamic activations and 128 × 128
+  blocks
+
+## Method
+
+- Maximum model length: 16,384
+- Maximum batched tokens / sequences: 2,048 / 8
+- KV cache: FP8
+- Speculative decoding: DSpark, 6 speculative tokens
+- Single-stream result: greedy 400-token completions over three prompt classes;
+  token counts came from final API usage records
+- Sustained result: one 800-completion-token request
+- Prefill result: 2,941 input tokens and one output token
+- Concurrency ladder: one measured batch each at c=1, 2, 4, and 8 with 400
+  completion tokens per request
+
+## Results
+
+| Metric | Value |
+|---|---:|
+| Cold single-stream decode | 51.06 tok/s |
+| Warm single-stream decode | **59.78 tok/s** |
+| Sustained decode | **56.6 tok/s** |
+| Cold / warm TTFT | 0.214 / **0.163 s** |
+| Uncached prefill | **325.5 tok/s** |
+| Aggregate c=1 / 2 / 4 / 8 | 101.21 / 114.68 / **169.65** / 133.95 tok/s |
+
+## Correctness and failures
+
+- Text requests completed and returned final usage accounting.
+- Image input was rejected with HTTP 400 because the tested SM80 runtime did
+  not wire the vision tower.
+- Concurrency 4 was the measured stable throughput peak.
+- Concurrency 16 wedged in the speculative draft path and is excluded from the
+  stable envelope.
+- No task-quality evaluation was captured in this snapshot.
+
+## Evidence
+
+- [Redacted structured snapshot](2026-08-31-deepseek-v4-flash-vision-exp-cmp170hx.json)
+- Classification: measured text performance; vision compatibility failed;
+  immutable runtime source pin untested


### PR DESCRIPTION
## Summary

- Add the DeepSeek-V4-Flash-Vision-Exp four-card measurements to the root README scoreboard, including decode, prefill, concurrency, and the failed vision gate.
- Add a redacted structured snapshot and normalized benchmark notes so every displayed number has a public source.
- Keep the result explicitly provisional because vision failed and the measured runtime lacks an immutable source revision.

## Test plan

- [x] Parse the structured JSON with Python.
- [x] Run git diff --check.
- [x] Run the GPU club public-boundary scanner.
- [x] Verify README and benchmark-table values against the redacted measurement snapshot.