### PR TITLE
Add per-model guide pages to reach Unsloth doc parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The CMP 170HX shares useful traits with A100-class hardware, including SM80 comp
 | Choose an AI workload | [Workload matrix](docs/WORKLOADS.md) |
 | Read the consolidated lessons | [What we learned](docs/LESSONS.md) |
 | See every model tried on this card | [Model status](docs/MODEL-STATUS.md) |
+| Run a specific model: quick start, settings, troubleshooting | [Model guides](docs/models/README.md) |
 | Read an executed experiment notebook | [Notebooks](notebooks/README.md) |
 
 ## Notebooks

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,11 @@
+# Model guides
+
+One page per model family this club has measured on CMP 170HX. Each guide is the durable how-to: quick-start commands, recommended settings, troubleshooting, and the current benchmark numbers, kept in sync with the receipts in the model's evidence repository. The executed notebook under `notebooks/` is the proof that a specific run happened; the guide here is what you run next.
+
+| Model | Best measured | Status | Guide |
+|---|---|---|---|
+| DeepSeek-V4-Flash-Vision-Exp | 220.2 tok/s aggregate decode (c=8, text path) | Text measured; vision measured, partial (c=2 ceiling) | [deepseek-v4-flash-vision-exp.md](deepseek-v4-flash-vision-exp.md) |
+| DeepSeek-V4-Flash-0731 | 83.3 tok/s aggregate decode (3 cards, local) | Measured, pending evidence repair | [deepseek-v4-flash-0731.md](deepseek-v4-flash-0731.md) |
+| Qwen3.8-27B | 147.7 tok/s decode (1 card, 255 W rented) | Measured, pending evidence repair | [qwen3.8-27b.md](qwen3.8-27b.md) |
+
+For every model this club has ever tried, including negative results and planned attempts, see [docs/MODEL-STATUS.md](../MODEL-STATUS.md). For the normalized cross-model benchmark ledger, see [docs/BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/models/deepseek-v4-flash-0731.md
+++ b/docs/models/deepseek-v4-flash-0731.md
@@ -1,0 +1,142 @@
+# DeepSeek-V4-Flash-0731 on CMP 170HX
+
+`deepseek-ai/DeepSeek-V4-Flash-0731` ships native MXFP4 experts plus FP8 e4m3 attention, 48 shards, about 148 GB. This club's own 3-card measurement reached 83.3 tok/s aggregate decode at 180 W with DSpark speculative decoding at k=5. A separate community 4-card reference run (not this club's own, from allover326) reached 98.1 tok/s and verified the full 1,047,736-token context window. This checkpoint is also the baseline the vision-capable `DeepSeek-V4-Flash-Vision-Exp` fork builds on — see `deepseek-v4-flash-vision-exp.md` for the vision recipe.
+
+## Run on CMP 170HX
+
+| Cards | VRAM/card | Format | Runtime | Partition | k (DSpark) | KV cache | Context | Measured decode | Status |
+|---|---:|---|---|---|---:|---|---:|---|---|
+| 3 (180 W, local) | untested | MXFP4 experts + FP8 e4m3 | SM80 vLLM fork (source build), PP3 | `15,15,13` | 5 | fp8 | 16,384 | 83.3 tok/s aggregate (technical 73.4 / prose 72.4 / code 116.6) | Measured, pending evidence repair |
+| 4 (community reference) | untested | Same | SM80 vLLM fork, PP4 | untested split | 5 | fp8 | 1,047,736 (full context verified) | 98.1 tok/s aggregate | Measured, upstream reference — not this club's own run |
+| 4 (PP4, acceptance study) | untested | Same | SM80 vLLM fork, PP4 | untested split | 5 | fp8 | untested | Not a throughput row; acceptance length 3.03 (per-position 0.730/0.569/0.372/0.226/0.131) | Measured, from `docs/LESSONS.md` |
+| 4 (PP4, k=7 comparison) | untested | Same | SM80 vLLM fork, PP4 | untested split | 7 | fp8 | untested | 60.3 tok/s aggregate — worse than k=5; acceptance never extends past ~3 tokens | Measured, negative result: do not raise k above the checkpoint's block size |
+
+`num_speculative_tokens` must be at least the checkpoint's `dspark_block_size` (5, for this checkpoint). Below it, output is garbled, not merely lower-acceptance. Above it measures worse, not better — see the k=7 row.
+
+## Quick start
+
+### 1. Build the image
+
+No prebuilt club GHCR image is published for this checkpoint. The precompiled vLLM wheel (`VLLM_USE_PRECOMPILED=1`) ships without `vllm._C`, the custom op this SM80 fork's patches need — the engine fails at CUDA-graph capture, not at import, if you try to skip the build. A full source build is required:
+
+```bash
+export TORCH_CUDA_ARCH_LIST=8.0
+# build from nvidia/cuda:13.0.2-cudnn-devel or an equivalent real CUDA
+# toolkit image; pip CUDA wheels alone leave an nvcc/FlashInfer header
+# mismatch. Measured build time: ~62 min compile + ~13 min export, ~78 min
+# total wall time from scratch.
+```
+
+### 2. Download the weights
+
+```bash
+pip install -U huggingface_hub
+hf download deepseek-ai/DeepSeek-V4-Flash-0731 --revision <pin-before-use> --local-dir <weights>
+```
+
+Pin the exact revision from your own `hf download` output; none is recorded in the sanitized notes reviewed for this page.
+
+### 3. Launch — 3 cards, PP3
+
+```bash
+docker run -d --name <container> --gpus '"device=0,1,2"' \
+  -e VLLM_PP_LAYER_PARTITION=15,15,13 \
+  -v <weights>:/model:ro --shm-size=16g -p 18010:8000 \
+  <your-built-image> \
+  vllm serve /model --served-model-name dsv4-0731 \
+  --pipeline-parallel-size 3 --kv-cache-dtype fp8 \
+  --max-model-len 16384 --gpu-memory-utilization 0.95 \
+  --tokenizer-mode deepseek_v4 \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5}'
+```
+
+`VLLM_PP_LAYER_PARTITION=15,15,13` is required on 3 cards, not optional — the default even split (`15,14,14`) fails during the Marlin FP4 expert repack because the last rank also carries `lm_head` and the DSpark drafter. `gpu-memory-utilization 0.95` is required too: 0.85 and 0.93 both fail KV allocation on that same last rank.
+
+### 4. First request
+
+```bash
+curl http://localhost:18010/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "dsv4-0731",
+    "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+    "temperature": 0,
+    "max_tokens": 8
+  }'
+```
+
+Text-only. No image-input example applies to this checkpoint — see `deepseek-v4-flash-vision-exp.md` for the vision-capable sibling.
+
+## Recommended settings
+
+- **Sampling for throughput benches:** greedy decoding, three prompt classes (technical, prose, code), 400 completion tokens per request.
+- **Speculative decoding:** DSpark at k=5, matched to this checkpoint's `dspark_block_size`. Do not raise it — k=7 measured worse (60.3 vs. 83.3–98.1 tok/s).
+- **KV cache:** fp8. Required by this fork's `fp8_ds_mla` layout assertion, not optional.
+- **Topology:** pipeline parallel, not tensor parallel. On this fabric (no NVLink, no P2P over PCIe Gen2 x4), PP beats TP by 6.6x on prefill (5,321 vs. 801 tok/s at 77k context) and roughly 2x on aggregate decode.
+- **gpu-memory-utilization:** 0.95 on 3 cards, 0.85 on 4 cards. Higher is not always safer — see Troubleshooting.
+- **Context:** 16,384 measured locally; the community 4-card reference verified the full 1,047,736-token window.
+
+## Troubleshooting
+
+**Precompiled wheel silently lacks the custom op.** `VLLM_USE_PRECOMPILED=1` installs without `vllm._C`; the failure surfaces at CUDA-graph capture, far from the actual cause. Build from source whenever a patch touches `csrc/`.
+
+**Editable installs avoid most rebuilds.** vLLM installed with `pip install -e .` lets patched Python files be bind-mounted read-only over the checkout, taking effect with no rebuild. Only `csrc/` changes force a real rebuild (~62 minutes). This recipe ships five patched files this way.
+
+**Verify a patch with three checks, not one.** `py_compile` (syntax only) and an import smoke test both passed on a real shipped bug; only an undefined-name scan (pyflakes) caught it. Run all three before trusting a patched build.
+
+**Uneven layer partition costs KV capacity.** Rebalancing the 4-card partition away from an even split grew the KV pool about 85% (798,660 to 1,476,563 tokens at `max-model-len 163840`) by removing an 8.7 GiB rank imbalance on the `lm_head`-heavy last rank.
+
+**Wrong `gpu-memory-utilization` fails KV allocation, not the model.** On 3 cards, 0.85 and 0.93 both fail; 0.95 works (leaves 7.7 GiB of KV against the last rank's 51.8 GiB of weights plus activations and CUDA graphs). On 4 cards, going above 0.85 takes headroom from activations and graph capture — 0.90 with the DSpark draft resident OOMs at capture time.
+
+**NFS vs. NVMe boot times.** This checkpoint is about 148 GB. Loading from NFS-backed shared storage measured about 31 MiB/s aggregate, roughly 22 minutes for weight loading plus about 7 minutes of CUDA graph capture. Local NVMe-class storage cuts the load leg by 16–25x.
+
+**`--gpus device=...` list after a crash.** After an OOM crash, `--gpus all` can silently assign zero devices to the next container — stale cgroup state from the crash. Use `--gpus '"device=0,1,2"'` (or your card list) explicitly.
+
+**Driver recovery after an OOM storm.** A multi-rank OOM kill can leave every GPU showing NVRM assertion failures and `cuInit` returning `CUDA_ERROR_NO_DEVICE` host-wide. `rmmod nvidia_uvm nvidia` then `modprobe nvidia nvidia_uvm` restores the devices without a VM reboot; reloading `nvidia_uvm` alone does not.
+
+**2,941-token prefill OOM does not apply here.** That limit is specific to the reference TP4 runtime used for the vision-capable sibling checkpoint's correctness milestone, not to this PP3/PP4 vLLM recipe — see `deepseek-v4-flash-vision-exp.md` for that runtime's limits.
+
+## Benchmarks
+
+### Three cards, PP3, DSpark k=5, 180 W (measured 2026-08-30, pending evidence repair)
+
+| Prompt class | Decode throughput |
+|---|---:|
+| Technical | 73.4 tok/s |
+| Prose | 72.4 tok/s |
+| Code | 116.6 tok/s |
+| Aggregate | **83.3 tok/s** |
+
+Uncached prefill: 2,965 tok/s at 5,399 input tokens. Draft-token acceptance: 5.07–5.32 tokens (81–86%).
+
+### Four cards, PP4, DSpark k=5 (community reference, not this club's own run)
+
+| Metric | Value |
+|---|---:|
+| Aggregate decode | 98.1 tok/s |
+| Prefill (77k context) | 5,321 tok/s |
+| Context verified | Full 1,047,736 tokens |
+
+### Speculative-decoding sensitivity (PP4, from `docs/LESSONS.md`)
+
+| k | Mean acceptance length | Aggregate decode |
+|---:|---|---:|
+| 5 | 3.03 | 98.1 tok/s |
+| 7 | 1.43–2.51 | 60.3 tok/s — worse, do not use |
+
+### Concurrency behavior (PP4, from `docs/LESSONS.md`)
+
+DSpark keeps winning through 64 concurrent requests on pipeline parallel (712.8 vs. 472.0 tok/s plain decode at c=64). On tensor parallel, the same technique goes negative above about 8 concurrent requests — a pipeline-parallel-specific result, not a general DSpark property.
+
+## Artifacts
+
+- **Evidence repository:** [PixelML/DeepSeek-V4-Flash-0731-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-0731-CMP-170HX). Sanitized receipts for the 3-card run are an open PR there as of this writing.
+- **GHCR image:** none published for this recipe as of this writing; built from source per the Quick start above.
+- **Checkpoint:** [deepseek-ai/DeepSeek-V4-Flash-0731](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) — pin an exact revision before use.
+- **Patch series:** SM80 vLLM fork and patches from [allover326/vllm-dsa-mtp-sm80](https://github.com/allover326/vllm-dsa-mtp-sm80) and [allover326/deepseek-v4-cmp170hx](https://github.com/allover326/deepseek-v4-cmp170hx).
+- **Executed notebook:** [notebooks/2026-08-30-deepseek-v4-flash-0731-3card-pp3-vllm.ipynb](../../notebooks/2026-08-30-deepseek-v4-flash-0731-3card-pp3-vllm.ipynb).
+
+## Changelog
+
+- **2026-08-30** — 3-card local run measured (83.3 tok/s aggregate decode, DSpark k=5, 180 W); sanitized receipt chain pending merge in the evidence repository.
+- **Undated (community reference)** — 4-card reference run from allover326 measured 98.1 tok/s aggregate decode and verified the full context window; kept as upstream context, not this club's own measurement.

--- a/docs/models/deepseek-v4-flash-vision-exp.md
+++ b/docs/models/deepseek-v4-flash-vision-exp.md
@@ -1,0 +1,218 @@
+# DeepSeek-V4-Flash-Vision-Exp on CMP 170HX
+
+`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` is DeepSeek's vision-capable Flash checkpoint: FP8 e4m3 weights, 48 shards, about 156 GiB. On this club's 4-card CMP 170HX rig it serves both text and images from one SM80 vLLM fork, pipeline parallel 4, DSpark speculative decoding at k=6. The text path is a measured performance benchmark (220.2 tok/s aggregate decode at c=8). The vision path is a measured but partial benchmark: functional gates and image correctness pass, and the concurrency ladder tops out at c=2 before the server's known crash point at c=4. A separate reference TP4 runtime, kept as history, produced the first real-image completion of this checkpoint on Ampere hardware at about 0.9 tok/s — a correctness result, not a speed result.
+
+Read this page for the settings and commands. Read the executed notebooks for the full protocol and raw receipts.
+
+## Run on CMP 170HX
+
+| Cards | VRAM/card | Format | Runtime | Image tag | Partition | Speculative k | KV cache | Context | Measured decode | Status |
+|---|---:|---|---|---|---|---:|---|---:|---|---|
+| 4 | ~51–61 GiB under load | FP8 e4m3 | SM80 vLLM fork, PP4 | `vllm-deepseek-v4-sm80-20260902` | `11,11,11,10` | 6 (DSpark) | fp8 | 16,384 | 97.4 tok/s c=1, 220.2 tok/s c=8 (median of 3) | Measured, text path |
+| 4 | ~51–61 GiB under load | FP8 e4m3 | SM80 vLLM fork, PP4, vision-enabled (Path 3) | `vllm-deepseek-v4-vision-sm80-20260902` | `11,11,11,10` | 6 (DSpark) | fp8 | 16,384 | 163.1 tok/s c=1 text-only, 45.3 tok/s c=1 text+image | Measured, partial — server crashes at c=4 |
+| 4 | ~44.4 GiB weights resident | FP8 → BF16 fallback | Reference TP4 runtime + SM80 patches | — (source build, no published image) | TP4 | none | BF16 | ≤ ~1,024 input tokens (OOM above) | ~0.9 tok/s, batch 1 | Correctness only, history |
+| 3 | untested | FP8 e4m3 | SM80 vLLM fork, PP3 | — | `15,15,13` | 5 (DSpark) | fp8 | 16,384 | untested on this checkpoint (see `deepseek-v4-flash-0731.md` for the sibling checkpoint's 3-card numbers) | Untested |
+
+Only `11,11,11,10` boots cleanly on 4 cards. Two other partitions failed before serving traffic: `12,12,12,7` exits 137, `12,12,11,8` hits a device-side assert on the first request.
+
+## Quick start
+
+### 1. Pull the image
+
+```bash
+docker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-sm80-20260902
+```
+
+For the vision-enabled build, pull the vision tag instead:
+
+```bash
+docker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-vision-sm80-20260902
+```
+
+### 2. Download the weights, pinned to the exact revision
+
+```bash
+pip install -U huggingface_hub
+hf download deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
+  --revision 86f746b36186f0e567729a5c06a8c918caba82a9 \
+  --local-dir <weights>
+```
+
+Verify shard count (48) and total bytes against a manifest before serving. Do not trust an unverified cache — see Troubleshooting below for why.
+
+### 3. Launch — text path
+
+```bash
+docker run -d --name <container> --gpus '"device=0,1,2,3"' \
+  -e VLLM_PP_LAYER_PARTITION=11,11,11,10 \
+  -v <model-storage>/deepseek-v4-flash-vision-exp@86f746b3:/model:ro \
+  --shm-size=16g -p 18098:8000 \
+  ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-sm80-20260902 \
+  vllm serve /model --served-model-name dsv4v \
+  --pipeline-parallel-size 4 --kv-cache-dtype fp8 \
+  --block-size 256 --max-model-len 16384 --max-num-batched-tokens 2048 \
+  --max-num-seqs 8 --tokenizer-mode deepseek_v4 \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":6}'
+```
+
+This image serves text only. It does not carry the vision encoder.
+
+### 4. Launch — vision path (confirmed working, boot attempt 5)
+
+```bash
+docker run -d --name <container> --gpus '"device=0,1,2,3"' \
+  -e HF_HUB_OFFLINE=1 \
+  -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_PP_LAYER_PARTITION=11,11,11,10 \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 \
+  -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+  -v <model-storage>/deepseek-v4-flash-vision-exp@86f746b3:/model:ro \
+  --shm-size=16g -p 18099:8000 \
+  ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-vision-sm80-20260902 \
+  vllm serve /model --served-model-name deepseek-v4-flash-vision-exp \
+  --pipeline-parallel-size 4 --kv-cache-dtype fp8 \
+  --block-size 256 --max-model-len 16384 --max-num-batched-tokens 2048 \
+  --trust-remote-code --gpu-memory-utilization 0.90 --max-num-seqs 8 \
+  --no-enable-flashinfer-autotune --tokenizer-mode deepseek_v4 \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":6}' \
+  --hf-overrides '{"architectures":["DeepseekV4ForConditionalGeneration"]}' \
+  --limit-mm-per-prompt '{"image": 2}'
+```
+
+Expect a 30–45 minute cold boot from network storage, or 8–15 minutes once weights are staged on local NVMe (see Troubleshooting).
+
+### 5. First request — text
+
+```bash
+curl http://localhost:18098/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "dsv4v",
+    "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+    "temperature": 0,
+    "max_tokens": 8
+  }'
+```
+
+### 6. First request — text and image
+
+```bash
+curl http://localhost:18099/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "deepseek-v4-flash-vision-exp",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Name the two colors this gradient blends between, left color first."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,<BASE64_IMAGE>"}}
+      ]
+    }],
+    "temperature": 0,
+    "max_tokens": 32
+  }'
+```
+
+A 64x64 gradient image, encoded as a `data:image/png;base64,...` URL, is what the vision golden corpus uses. This is the request shape that returned `"Red, green"` on the measured 2026-09-02 run.
+
+## Recommended settings
+
+- **Sampling for correctness checks:** `temperature=0`, greedy, so output is comparable to the golden corpus.
+- **Sampling for throughput benches:** greedy decoding, `ignore_eos=true`, 400 completion tokens per request, three repetitions per concurrency level, one warmup rep discarded. Count tokens from the final `usage.completion_tokens` object, not from streamed events.
+- **Prompt limits:** the measured prefill benchmark uses a 2,941-token uncached prompt. The reference TP4 runtime OOMs above roughly 1,024 input tokens (see Troubleshooting); the vLLM PP4 path does not share that ceiling.
+- **Image limits:** the vision launch command sets `--limit-mm-per-prompt '{"image": 2}'`. The measured golden corpus uses one image per request.
+- **Concurrency, vision build:** keep concurrency at c=2 or below on the vision-enabled image. The text-only ladder on that same build crashed at c=4 (`EngineCore` died, `RuntimeError: cancelled` in the shared-memory broadcast queue), and text+image concurrency above c=2 was not attempted given that crash history. The text-only image (no vision encoder) has its own, separate ceiling at c=16.
+- **Context:** `--max-model-len 16384`, `--max-num-batched-tokens 2048`. Not tested past this window on this checkpoint.
+- **KV cache:** `fp8`. Cuts memory versus BF16 KV at some decode/prefill cost — see `docs/LESSONS.md` section d for the measured trade on a sibling checkpoint (Qwen3.8-27B): -3.4% decode, -19.5% prefill.
+
+## Troubleshooting
+
+**1. Eager weight load exhausts host RAM.** The default eager `safetensors` load reads each shard whole into host RAM. Four pipeline ranks loading a 156 GiB checkpoint concurrently exhausted a 94 GiB host and the kernel silently killed workers at 7 of 48 shards, no traceback. Fix: use the default streaming `safe_open` load instead of `--safetensors-load-strategy eager`.
+
+**2. Missing multimodal plan API.** The pinned model code's processor calls `_plan_prompt_updates`, a method this vLLM fork does not carry. Fix: a compatibility shim in `vllm/multimodal/processing/processor.py`.
+
+**3. Processor never returns `input_ids`.** `DeepseekV4VLProcessor.__call__` tokenized nothing, causing `KeyError: 'input_ids'` during profiling. Fix: override `_call_hf_processor` to tokenize and merge `input_ids` in, and override `_hf_processor_applies_updates` to return `False`.
+
+**4. Broadcast weights never finalized.** `DeepseekV4ForCausalLM.load_weights()` skipped `process_weights_after_loading()`, so `hc_attn_fn_broadcast` stayed `None` and image profiling tripped an assertion. Fix: call it, matching the pinned reference's own load order.
+
+**5. CUDA-graph capture nulls `input_ids` on non-first ranks.** DeepSeek V4 Vision's MoE router needs raw `input_ids` on every rank (`requires_raw_input_tokens = True`); the graph-capture path did not carry the same guard the normal forward path had. Fix: added the guard to `cudagraph_utils.py`. This was the fifth and last fix before the vision build reached READY.
+
+**Eager vs. streaming load.** Prefer the default streaming `safe_open` load over `--safetensors-load-strategy eager` on any multi-rank boot; the eager path is a host-RAM-exhaustion hazard proportional to rank count, not just model size.
+
+**NFS vs. NVMe boot times.** A cold boot from NFS-backed shared storage measured 42 minutes (2,515 s: 1,146 s for ranks 0–2, 2,270 s for rank 3, which also carries the draft head). NFS throughput measured about 31 MiB/s aggregate. Staging the same checkpoint on local NVMe cuts this to roughly 8–15 minutes.
+
+**`--gpus device=...` list after a crash.** After an OOM crash, `--gpus all` can assign zero devices to a new container — stale cgroup state left over from the crash. Use an explicit device list, `--gpus '"device=0,1,2,3"'`, instead of `all`.
+
+**Driver recovery after an OOM storm.** A multi-rank OOM kill can leave the kernel log showing NVRM assertion failures on every GPU, with `cuInit` returning `CUDA_ERROR_NO_DEVICE` host-wide. Reloading `nvidia_uvm` alone does not clear it. The full sequence — `rmmod nvidia_uvm nvidia` then `modprobe nvidia nvidia_uvm` — restores all devices without a VM reboot.
+
+**2,941-token prefill OOM on the reference TP4 runtime.** The reference runtime (not the vLLM path) needs 6.8 GiB per rank for a 2,941-token prompt and 7.8 GiB for a 2,048-token prompt; both exceeded free memory with about 44.4 GiB of weights already resident per card. Reliable single-request prefill on that runtime stays below about 1,024 tokens. This limit does not apply to the vLLM PP4 path, whose measured prefill benchmark uses the full 2,941-token prompt without issue.
+
+**c=4 crash on the vision build.** At c=4, rep 3 of 3, the vLLM `EngineCore` process died mid-batch: `RuntimeError: cancelled` from `shm_broadcast.py`, `acquire_read`. All 4 in-flight requests got `HTTP 500`; the container exited cleanly (code 0). GPUs stayed at 42–47°C through the crash, no Xid or ECC events. Per this club's standing operating instruction, the session did not restart the server automatically — restart it manually and stay at c=2 or below.
+
+## Benchmarks
+
+### Text path, four cards, PP4 + DSpark k=6
+
+Greedy decoding, 400 completion tokens, `ignore_eos`, one warmup plus three reps per level, tokens counted from the final `usage` object. Measured 2026-09-02.
+
+| Concurrency | Aggregate decode | Notes |
+|---|---:|---|
+| c=1 | 97.4 tok/s (median of 3; range 57.6–123.5) | |
+| c=2 | 103.7 tok/s (median of 3; range 96.6–159.2) | |
+| c=4 | 165.5 tok/s (median of 3; range 140.3–203.2) | |
+| c=8 | 220.2 tok/s (median of 3; range 206.3–232.0) | Best measured aggregate |
+| c=16 | Failed | Device-side assert in the draft-decode path, reproduced twice |
+
+Uncached prefill, 2,941 input tokens: 2,352 tok/s warm (362 tok/s first cold prefill). Warm TTFT: 0.394 s.
+
+### Vision path, four cards, PP4 + DSpark k=6 (Path 3)
+
+Measured 2026-09-02, partial.
+
+| Metric | Value |
+|---|---:|
+| Functional gates | PASS, 3/3 identical reps |
+| Golden corpus, image rows (10) | PASS, 10/10 keyword match |
+| Golden corpus, text rows (20) | 15/20 keyword match, 10/20 exact-match vs. DGX Spark reference |
+| Decode, c=1, text-only | 163.06 tok/s aggregate (median of 3) |
+| Decode, c=2, text-only | 116.57 tok/s aggregate (median of 3) |
+| Decode, c=4, text-only | FAIL — server crashed, rep 3 of 3 |
+| Decode, c=8 / c=16, text-only | Not measured |
+| Decode, c=1, text+image | 45.32 tok/s aggregate (median of 3) |
+| Decode, c=2, text+image | 78.23 tok/s aggregate (median of 3) |
+| Decode, c=4 and above, text+image | Not attempted, given the c=4 text-only crash |
+| Uncached prefill, 2,941 tokens | 2,352.42 tok/s (median of 3) |
+| Warm streaming TTFT | 0.386 s (median of 3) |
+
+### Reference TP4 runtime — vision correctness milestone (history)
+
+Not a serving benchmark. Batch 1, no streaming, no speculative decoding.
+
+| Metric | Value |
+|---|---:|
+| Decode, c=1, greedy 401 tokens, 3 reps | 0.88–0.93 tok/s |
+| Wall time per 401-token completion | 431–454 s |
+| Prefill, 512 input tokens | 8.7–9.8 s wall |
+| Prefill, 256 input tokens | 7.4–7.5 s wall |
+| Weights resident per card | ~44.4 GiB |
+
+Real-image completion: PASS. The model named colors present in a 64x64 gradient image and absent from the text prompt. No-image and wrong-image controls also passed.
+
+### Cross-platform context (not a head-to-head)
+
+The same checkpoint at the same revision also runs on a two-node DGX Spark kit (GB10, vLLM, TP=2): c=1 36.9 tok/s, c=6 112.7 tok/s aggregate, uncached prefill 1,789 tok/s, vision PASS. Full numbers and cost/watt comparison: `docs/BENCHMARKS.md#cross-platform-4x-cmp-170hx-vs-2x-dgx-spark`. The two platforms differ in runtime, parallelism, and memory budget — read this as context, not a controlled comparison.
+
+## Artifacts
+
+- **GHCR images:** `ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-sm80-20260902` (text path), `ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-vision-sm80-20260902` (vision path). A pinned digest for a related club image: `ghcr.io/pixelml/club-170hx@sha256:90a1419e8ceaad3542153ef4e2a1d94a69b9af03cce7b0a1b267dd1dad55b9d7` — pin the digest for the tag you pull before relying on it in production.
+- **Evidence repository:** [PixelML/DeepSeek-V4-Flash-Vision-Exp-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-Vision-Exp-CMP-170HX) — full receipts, launch scripts, and patches.
+- **Hugging Face collection:** [PixelML/club-170hx: verified on CMP 170HX (SM80)](https://huggingface.co/collections/PixelML/club-170hx-verified-on-cmp-170hx-sm80-6a97bf4edc20b52c5cf454e3).
+- **Checkpoint:** [deepseek-ai/DeepSeek-V4-Flash-Vision-Exp](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp), revision `86f746b36186f0e567729a5c06a8c918caba82a9`.
+- **Patch series:** the five vision boot fixes and the SM80 fallback patches build on [allover326/vllm-dsa-mtp-sm80](https://github.com/allover326/vllm-dsa-mtp-sm80) and [allover326/deepseek-v4-cmp170hx](https://github.com/allover326/deepseek-v4-cmp170hx). Full patch detail: `docs/LESSONS.md` section f.1.
+- **Executed notebooks:** [text path](../../notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-pp4-vllm.ipynb), [vision path](../../notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-vision-pp4-vllm.ipynb).
+
+## Changelog
+
+- **2026-09-02** — Vision path measured on the SM80 vLLM PP4 fork (Path 3): functional gates and image correctness pass, text-only ladder crashes at c=4, text+image ladder measured through c=2. Text path re-measured on the normalized protocol through c=16 (220.2 tok/s aggregate at c=8, device-side assert at c=16).
+- **2026-08-31** — Earlier text-path ladder and single-stream run, superseded by the 2026-09-02 normalized text benchmark. Numbers kept in `docs/BENCHMARKS.md` as historical, not current.
+- **2026-08-31 (approx.)** — Reference TP4 runtime achieves the first real-image completion of this checkpoint on Ampere hardware, at about 0.9 tok/s. Kept as the correctness-only history milestone.

--- a/docs/models/qwen3.8-27b.md
+++ b/docs/models/qwen3.8-27b.md
@@ -1,0 +1,123 @@
+# Qwen3.8-27B on CMP 170HX
+
+`Qwen3.8-27B`, W4A16-AutoRound quantized with DFlash2 speculative decoding, is the fastest working recipe this club has measured on a single CMP 170HX card: 140.3 tok/s decode at a 180 W local power cap, 95% of a 255 W rented card's decode rate at 71% of its power draw. The card is bandwidth-bound, so the denser W8A16 checkpoint measured slower (31.6 tok/s), not faster. Evidence lives in [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX); the sanitized receipt chain for the three-card local runs is still an open PR there, so the numbers below are platform context until that repair lands.
+
+## Run on CMP 170HX
+
+| Cards | VRAM/card | Format | Runtime | Power | k (DFlash2) | KV cache | Context | Measured decode | Status |
+|---|---:|---|---|---:|---:|---|---:|---|---|
+| 1 (rented) | ~57.8 GiB peak | W4A16-AutoRound ("fast variant") | vLLM 0.27.1 + DFlash2 | 255 W | 7 | BF16 | 65,536 | 147.7 tok/s @ 256 tok, 134.5 tok/s @ 900 tok | Measured |
+| 3 (local, one card each) | untested | W4A16-AutoRound (dbirks) | vLLM 0.27.1 + DFlash2 | 180 W | 7 | BF16 | untested | 133.6–140.3 tok/s decode, 136.38 tok/s mean | Measured 2026-08-30, pending evidence repair |
+| 1 (rented) | untested | W8A16 (official checkpoint) | vLLM 0.27.1 + DFlash2 | 255 W | 7 | BF16 | untested | 31.6 tok/s decode, acceptance 2.9 | Measured, negative vs. W4A16 |
+| 1 | untested | W4A16-AutoRound | vLLM 0.27.1 + DFlash2, FP8 KV | 180 W | 7 | FP8 | 131,072 | -3.4% decode, -19.5% prefill vs. BF16 KV at the same context | Measured trade-off, not a standalone recipe |
+
+No club-published GHCR image exists for this recipe as of this writing; the reference run used a public CUDA base plus `pip install vllm==0.27.1` and source patches, not a prebuilt club image. Treat the docker step below as the pattern this club would ship, not a pulled artifact.
+
+## Quick start
+
+### 1. Build or pull a vLLM 0.27.1 image with the DFlash2 patch set applied
+
+No club GHCR tag is published for this recipe. Reproduce it from a public CUDA base:
+
+```bash
+docker pull nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04
+# then: pip install vllm==0.27.1 and apply the DFlash2 patches from the
+# upstream syv-ai recipe referenced in the evidence repository.
+```
+
+### 2. Download the weights
+
+```bash
+pip install -U huggingface_hub
+hf download lued/Qwen3.8-27B-INT8-W8A16-MTP --revision <pin-before-use> --local-dir <weights>
+hf download syvai/Qwen3.8-27B-DFlash2-W4A16 --revision <pin-before-use> --local-dir <draft>
+```
+
+The evidence repository does not carry a pinned revision hash for either repo in the sanitized notes reviewed for this page — pin one from your own `hf download` output before relying on it.
+
+### 3. Launch
+
+```bash
+docker run -d --name <container> --gpus '"device=0"' \
+  -v <weights>:/model:ro -v <draft>:/draft:ro \
+  --shm-size=8g -p 18020:8000 \
+  <your-image> \
+  vllm serve /model --served-model-name qwen3.8-27b \
+  --speculative-config '{"method":"dflash2","draft_model":"/draft","num_speculative_tokens":7}' \
+  --kv-cache-dtype bf16 --gpu-memory-utilization 0.90 --max-num-seqs 1 \
+  --max-model-len 65536
+```
+
+### 4. First request
+
+```bash
+curl http://localhost:18020/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3.8-27b",
+    "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+    "temperature": 0,
+    "max_tokens": 8
+  }'
+```
+
+Qwen3.8-27B is text-only on this recipe; no image-input example applies.
+
+## Recommended settings
+
+- **Sampling for throughput benches:** greedy decoding, fixed output lengths (256 and 900 tokens measured), tokens counted from the final usage object.
+- **Speculative decoding:** DFlash2 at `k=7`. Measured acceptance length 2.56–2.80 (255 W rented) and 2.85–3.32 (180 W local, better than the rented run). A 2.30x decode speedup over plain decoding was measured on the RTX 3090 baseline at the same recipe.
+- **KV cache:** BF16 is the default and the faster choice. FP8 KV was measured at -3.4% decode and -19.5% prefill versus BF16 KV at 131k context on the same server — FP8 KV buys long context, it does not come free.
+- **Power:** 180 W local reaches 95% of the 255 W rented card's decode rate at 71% of the power draw. Prefill reaches 91% of the 255 W rate at 180 W. TTFT is worse locally (about 190 ms vs. 76 ms), attributed to the PCIe Gen2 x4 host link, not the power cap.
+- **Context:** 65,536 measured on the rented single-card run; 131,072 measured for the FP8-KV comparison. Not tested beyond that on this checkpoint.
+
+## Troubleshooting
+
+**Private GHCR image returns 401.** An earlier attempt tried a prebuilt image (`syv-ai/qwen38-27b-rtx3090`) that turned out to be private: an anonymous manifest pull returned 401, and the container held no model. Check image pullability with an anonymous token request before renting a GPU around an image you have not verified is public.
+
+**SSH auth failure from an `authorized_keys` permission problem.** Blocked the first rented-node attempt entirely. Check key file permissions (`600`) and ownership before assuming a network or firewall issue.
+
+**Multi-GPU attempts died on disk size, not compute.** Two unrelated multi-GPU runs (GLM-5.3-Flash-AWQ at 8x, Qwen3.8-Flash-Next-AWQ at 4x) failed because rented instances shipped 17–20 GiB disks against 168–176 GiB models. Check disk size against model size before renting, independent of GPU count or VRAM.
+
+**A surprising low-power reading was contamination, not a real 3x power penalty.** A single-card run once reported 47.0 tok/s at 180 W, read at the time as "the power cap costs 3x." The number was contaminated by an overlapping model build on the same host and a pinned KV-cache allocation left over from a different card's default. A clean rerun at the same 180 W cap reached 135.3–140.3 tok/s — the real 180 W vs. 255 W gap is about 5%. Re-verify any surprising power number before trusting it.
+
+## Benchmarks
+
+### Single card, 255 W rented (measured)
+
+| Metric | Value |
+|---|---:|
+| Decode, 256 output tokens | 147.7 tok/s |
+| Decode, 900 output tokens | 134.5 tok/s |
+| TTFT | 76 ms |
+| Prefill, 6.6k-token prompt | 2,156 tok/s |
+| Peak VRAM | 57.8 GiB |
+| Peak power / clock / temp | 255 W / 1,455 MHz / 73°C |
+| Acceptance length | 2.56–2.80 |
+
+### Three cards, 180 W local, one card each (measured 2026-08-30, pending evidence repair)
+
+| Card | Decode, 256 tok | Decode, 900 tok | TTFT | Prefill |
+|---|---:|---:|---:|---:|
+| 0 | 135.31 tok/s | 121.28 tok/s | 201.2 ms | 1,957.3 tok/s |
+| 1 | 140.27 tok/s | 124.78 tok/s | 189.7 ms | 1,954.7 tok/s |
+| 2 | 133.57 tok/s | 119.94 tok/s | 181.4 ms | 1,926.0 tok/s |
+| Mean | **136.38 tok/s** | **122.00 tok/s** | **190.8 ms** | **1,946.0 tok/s** |
+
+Peak core temperature 51°C, peak memory temperature 61°C across the three runs.
+
+### RTX 3090 baseline, same recipe (measured, comparison only)
+
+122.42 tok/s decode (256 tok), 111.22 tok/s (900 tok), TTFT 181.5 ms, prefill 1,341.9 tok/s, 21.9 GiB VRAM, 390 W. The CMP 170HX measured about 1.21x faster on decode and 1.61x faster on prefill at the same recipe, and roughly 2.4x better tokens per watt.
+
+## Artifacts
+
+- **Evidence repository:** [PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX).
+- **GHCR image:** none published for this recipe as of this writing.
+- **Checkpoints:** `lued/Qwen3.8-27B-INT8-W8A16-MTP` (main), `syvai/Qwen3.8-27B-DFlash2-W4A16` (draft) — pin an exact revision before use; none is recorded in the sanitized evidence reviewed for this page.
+- **Patch series:** DFlash2 patches from the syv-ai reference stack, applied at container start.
+
+## Changelog
+
+- **2026-08-30** — Three-card local runs at 180 W measured (136.38 tok/s mean decode at 256 tokens); sanitized receipt chain still pending merge in the evidence repository.
+- **2026-08-28** — Single rented-card run at 255 W measured (147.7 tok/s decode); first-attempt private-image and SSH failures documented.

--- a/notebooks/2026-08-30-deepseek-v4-flash-0731-3card-pp3-vllm.ipynb
+++ b/notebooks/2026-08-30-deepseek-v4-flash-0731-3card-pp3-vllm.ipynb
@@ -20,7 +20,7 @@
     "hf download deepseek-ai/DeepSeek-V4-Flash-0731 --local-dir <weights>\n",
     "```\n",
     "\n",
-    "[Evidence: allover326/deepseek-v4-cmp170hx](https://github.com/allover326/deepseek-v4-cmp170hx)\n"
+    "[Model guide: DeepSeek-V4-Flash-0731](../docs/models/deepseek-v4-flash-0731.md)"
    ]
   },
   {

--- a/notebooks/2026-08-30-qwen3.8-27b-w4a16-dflash2-1card-vllm.ipynb
+++ b/notebooks/2026-08-30-qwen3.8-27b-w4a16-dflash2-1card-vllm.ipynb
@@ -20,7 +20,7 @@
     "hf download dbirks/Qwen3.8-27B-W4A16-AutoRound --local-dir <weights>\n",
     "```\n",
     "\n",
-    "[Evidence: PixelML/Qwen3.8-27B-CMP-170HX](https://github.com/PixelML/Qwen3.8-27B-CMP-170HX)\n"
+    "[Model guide: Qwen3.8-27B](../docs/models/qwen3.8-27b.md)"
    ]
   },
   {

--- a/notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-pp4-vllm.ipynb
+++ b/notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-pp4-vllm.ipynb
@@ -4,24 +4,7 @@
    "cell_type": "markdown",
    "id": "db9db32d",
    "metadata": {},
-   "source": [
-    "# DeepSeek-V4-Flash-Vision-Exp on 4x CMP 170HX (SM80) — vLLM PP4, DSpark k=6\n",
-    "\n",
-    "| Metric | Value |\n",
-    "|---|---|\n",
-    "| Decode, c=1 | 97.4 tok/s |\n",
-    "| Best aggregate (c=8) | 220.2 tok/s |\n",
-    "| Prefill, uncached (2,941 tok) | 2,352 tok/s warm (362 tok/s first cold prefill) |\n",
-    "| TTFT, warm | 0.394 s |\n",
-    "\n",
-    "![concurrency ladder chart](../assets/charts/2026-09-02-dsv4-vision-exp-4card-ladder.png)\n",
-    "\n",
-    "```\n",
-    "docker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-sm80-20260902\n",
-    "```\n",
-    "\n",
-    "[Release: dsv4-vision-exp-4card-2026-09-02](https://github.com/PixelML/club-170hx/releases/tag/dsv4-vision-exp-4card-2026-09-02)\n"
-   ]
+   "source": "# DeepSeek-V4-Flash-Vision-Exp on 4x CMP 170HX (SM80) — vLLM PP4, DSpark k=6\n\n| Metric | Value |\n|---|---|\n| Decode, c=1 | 97.4 tok/s |\n| Best aggregate (c=8) | 220.2 tok/s |\n| Prefill, uncached (2,941 tok) | 2,352 tok/s warm (362 tok/s first cold prefill) |\n| TTFT, warm | 0.394 s |\n\n![concurrency ladder chart](../assets/charts/2026-09-02-dsv4-vision-exp-4card-ladder.png)\n\n```\ndocker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-sm80-20260902\n```\n\n[Model guide: DeepSeek-V4-Flash-Vision-Exp](../docs/models/deepseek-v4-flash-vision-exp.md)\n"
   },
   {
    "cell_type": "code",

--- a/notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-vision-pp4-vllm.ipynb
+++ b/notebooks/2026-09-02-deepseek-v4-flash-vision-exp-4card-vision-pp4-vllm.ipynb
@@ -4,27 +4,7 @@
    "cell_type": "markdown",
    "id": "db2263f7",
    "metadata": {},
-   "source": [
-    "# DeepSeek-V4-Flash-Vision-Exp — vision on 4x CMP 170HX (SM80), vLLM\n",
-    "\n",
-    "| Metric | Value |\n",
-    "|---|---|\n",
-    "| Decode, c=1 (text-only / text+image) | 163.06 tok/s / 45.32 tok/s aggregate |\n",
-    "| Best aggregate throughput | 163.06 tok/s at c=1, text-only (c=4 crashed mid-run, see appendix) |\n",
-    "| Uncached prefill, 2,941 tokens | 2,352.42 tok/s (median of 3) |\n",
-    "| Warm streaming TTFT | 0.386 s (median of 3) |\n",
-    "\n",
-    "![gradient fixture](../assets/images/2026-09-02-deepseek-v4-flash-vision-exp-4card-vision-pp4-vllm-proof.png)\n",
-    "\n",
-    "Question: \"Name the two colors this gradient blends between, left color first.\"\n",
-    "Model answer: **\"Red, green\"** (`finish_reason=stop`, keyword match: true).\n",
-    "\n",
-    "```\n",
-    "docker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-vision-sm80-20260902\n",
-    "```\n",
-    "\n",
-    "[Evidence repository: DeepSeek-V4-Flash-Vision-Exp-CMP-170HX](https://github.com/PixelML/DeepSeek-V4-Flash-Vision-Exp-CMP-170HX)\n"
-   ]
+   "source": "# DeepSeek-V4-Flash-Vision-Exp — vision on 4x CMP 170HX (SM80), vLLM\n\n| Metric | Value |\n|---|---|\n| Decode, c=1 (text-only / text+image) | 163.06 tok/s / 45.32 tok/s aggregate |\n| Best aggregate throughput | 163.06 tok/s at c=1, text-only (c=4 crashed mid-run, see appendix) |\n| Uncached prefill, 2,941 tokens | 2,352.42 tok/s (median of 3) |\n| Warm streaming TTFT | 0.386 s (median of 3) |\n\n![gradient fixture](../assets/images/2026-09-02-deepseek-v4-flash-vision-exp-4card-vision-pp4-vllm-proof.png)\n\nQuestion: \"Name the two colors this gradient blends between, left color first.\"\nModel answer: **\"Red, green\"** (`finish_reason=stop`, keyword match: true).\n\n```\ndocker pull ghcr.io/pixelml/club-170hx:vllm-deepseek-v4-vision-sm80-20260902\n```\n\n[Model guide: DeepSeek-V4-Flash-Vision-Exp](../docs/models/deepseek-v4-flash-vision-exp.md)\n"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -34,7 +34,11 @@ cell. It holds, in this order and nothing else:
    states that plainly instead of showing a fake image.
 4. The pull command, one code line (`hf download ...` or `docker pull ...`).
 5. One link line: the release, the evidence repository, or the
-   Hugging Face collection.
+   Hugging Face collection. When the model has a guide page under
+   `docs/models/`, that link line points there instead — the guide is
+   the durable how-to (settings, troubleshooting, current numbers); this
+   notebook is the executed proof that one specific run happened. A model
+   with no guide page yet keeps the release/evidence/collection link.
 
 No pins, no protocol text, no prose paragraph belongs in this cell. If the
 notebook has an embedded video, that cell comes second, right after the


### PR DESCRIPTION
## Summary
- Add `docs/models/deepseek-v4-flash-vision-exp.md`, `docs/models/deepseek-v4-flash-0731.md`, and `docs/models/qwen3.8-27b.md`: durable how-to pages in the shape of Unsloth's model docs (run table by hardware/quant with VRAM and settings, quick start commands, recommended sampling/context/KV settings, troubleshooting, benchmark tables, artifact links, changelog).
- Add `docs/models/README.md` as the index, linked from README.md's "Start here" table.
- Point each model's notebook hero cell (the two DeepSeek-V4-Flash-Vision-Exp notebooks, the DeepSeek-V4-Flash-0731 notebook, and the Qwen3.8-27B notebook) at its guide page instead of the release/evidence-repo link, and update `notebooks/README.md`'s hero-cell convention to document this.
- All numbers are copied verbatim from `docs/BENCHMARKS.md`, `docs/MODEL-STATUS.md`, `docs/LESSONS.md`, and the notebooks' own receipts; nothing is re-derived or rounded.

## Structure mirrored from unsloth.ai/docs/models/deepseek-v4
- Hero summary paragraph
- "Run on CMP 170HX" table by card count/quant/runtime, with VRAM, image tag, partition, k, KV, context, measured throughput, status
- Quick start: pull/download/launch/first-request commands per path
- Recommended settings: sampling, context/KV guidance, stability notes
- Troubleshooting: numbered fixes tied to specific failure modes
- Benchmarks tables with protocol and dates
- Artifacts: image tags/digests, evidence repo, HF checkpoints, patch credit
- Dated changelog

## Data gaps per model
- **DeepSeek-V4-Flash-Vision-Exp**: vision concurrency ladder stops at c=2 (server crashes at c=4); TTFT and vision-path prefill beyond c=2 are untested.
- **DeepSeek-V4-Flash-0731**: no pinned revision hash or image digest in evidence; TTFT untested; no GHCR image published (source build only).
- **Qwen3.8-27B**: no pinned revision for either checkpoint in the sanitized evidence; no GHCR image published; multi-stream/concurrency throughput untested (single-stream only).

## Test plan
- [x] Diffed all new/edited files for private IPs, hostnames, VM identifiers, and secrets — none found.
- [x] Cross-checked every number against `docs/BENCHMARKS.md` / `docs/MODEL-STATUS.md` / `docs/LESSONS.md` / notebook receipts.
- [x] Verified the two notebook JSON diffs are single-line hero-cell link changes only.