### PR TITLE
GLM-5.3-Flash: 8x CMP 170HX rental bundle (onstart, queue, launchers, bench)

### DIFF
--- a/scripts/rental/README.md
+++ b/scripts/rental/README.md
@@ -1,0 +1,52 @@
+# Rental scripts — 8x CMP 170HX on Vast.ai
+
+Operator scripts for renting a multi-card CMP 170HX box by the hour and running
+this club's GLM-5.3-Flash work on it. They exist because the club's own node has
+four cards: anything that needs eight, or that needs a healthy PCIe link, has to
+be rented.
+
+**Status: prepared, not yet executed.** Nothing here has produced a published
+measurement. No rental in this bundle has been run to completion, so every
+timing in the runbook is a projection from the four-card box, not a measured
+rental figure. Treat the whole directory as a plan with executable parts.
+
+Two purposes, added in that order, sharing the same launcher and gate helpers:
+
+| Purpose | Entry point | State |
+|---|---|---|
+| 8-card inference measurement (TP4 / PP4 / TP8 sweep) | `run_queue.sh` | prepared, never run |
+| Drafter training + PP4 hidden-state extraction | `run_training.sh`, `run_extraction.sh` | prepared, never run |
+
+The second purpose was added on 2026-09-05, after the four-card PP4 lane became
+the [recipe of record](../../docs/models/glm-5.3-flash.md). The inference queue
+is therefore aimed at what four cards cannot answer — TP8, an eight-stage
+pipeline, and the same recipe on a healthy link — rather than at re-measuring
+the recipe of record.
+
+## Files
+
+| File | What it does |
+|---|---|
+| `RUNBOOK.md` | The operator procedure for both purposes: find an offer, rent, gate the checkpoint download, run, collect, destroy. Read it before anything else. |
+| `find_offer.sh` | Lists CMP 170HX offers, `verified=any`, sorted by PCIe bandwidth. |
+| `onstart.sh` | Instance bootstrap for the inference queue: checkpoint download with a byte-count gate. |
+| `onstart_train.sh` | Instance bootstrap for the training run: torch-import sanity only, no checkpoint pull. |
+| `launch_tp4.sh`, `launch_pp4.sh`, `launch_tp8.sh` | Direct-exec `vllm serve` launchers, one topology each. No nested docker: the rented instance runs the club image itself. |
+| `run_queue.sh` | The full measurement queue, resumable via per-step `DONE` markers. |
+| `run_training.sh`, `run_extraction.sh` | Drafter training sweep and PP4 slice extraction. |
+| `transfer_specdec.sh` | Relays training data from an internal source host to the rental, with a rate test per hop. |
+| `collect.sh` | Tars receipts and trimmed logs for transfer back. |
+| `bench/` | The measurement harness the queue calls: decode, prefill/TTFT, concurrency stability, context sweep, lossless check. |
+
+## Before you run any of this
+
+- The scripts assume the club's public image and a public checkpoint. They carry
+  no credentials, no host names and no internal paths. Anything internal is read
+  from an environment variable that fails closed when unset (`SPECDEC_SOURCE`,
+  `SPECDEC_DEST_HOST`, `SPECDEC_DEST_PORT`, `SRC_DATA_DIR`).
+- Spend caps and destroy triggers are in `RUNBOOK.md` section 5. They are the
+  point of the runbook, not paperwork around it.
+- Receipts from a rental go to a branch in the evidence repository, never
+  straight to `main`, and are sanitized the same way every other result set in
+  this club is. Rental-specific identifiers — instance ids, SSH endpoints, offer
+  ids — do not belong in a published receipt.

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -150,8 +150,11 @@ Caps: total spend <= $17 (balance ~$18.66), <= 6h instance time, destroy on comp
 2. Else 8x64GB Gen2x16 (49884606, $3.29/hr): 4 extraction + 4 training, ~5h max.
 3. Else any 4x64GB offer: training only (skip slice C).
 
-Disk >= 450GB required in all cases (178GB AWQ checkpoint + 82GB slice-C output + 18GB
-training data + headroom).
+Disk >= 450GB required in all cases. Math at commit `e03679f1` (checkpoints exported-set
+only, not the frozen shared weights — 9.4GB/run instead of 19GB/run): 178GB AWQ + ~41GB
+slice C at 1M tokens + 18GB training data (sliceB/target-shared/ref-drafter) + ~56GB
+checkpoints (6 runs) + ~29GB image = **~322GB of 500**. (At the superseded commit this
+was ~380GB — workable but far tighter; re-pin to `e03679f1` before renting.)
 
 ### Sequence
 
@@ -159,22 +162,26 @@ training data + headroom).
    checkpoint pull here — that's extraction-only and gated separately).
 2. From the orchestrating machine (not the rental): run `scripts/rental/transfer_specdec.sh`
    with `SPECDEC_SOURCE`, `SPECDEC_DEST_HOST`, `SPECDEC_DEST_PORT` set. It does a 1GB rate
-   test each hop, then relays tools tarball (sha256 `1fd9f29b...`, commit `eb1434a8`), sliceB
+   test each hop, then relays tools tarball (sha256 `ba8e8b00...`, commit `e03679f1`), sliceB
    (14GB), target-shared.safetensors (1.9GB), ref-drafter (2.2GB) via a local staging dir
    (source has no route to the rental). Ends with the mandatory gate:
    `tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9` then `OK`.
    **Stop if this string differs — do not train on it.**
 3. On the rental: `scripts/rental/run_training.sh [NUM_GPUS_TRAIN]` — runs the reference
    band check first (`ref_eval2.py`, must land `IN BAND (~36%)` against alpha 0.3614),
-   then launches bs8-lr{1.5e-4,3e-4} immediately; if >=6 training cards, waits (<=30 min)
-   for bs8 `best.pt` then launches bs13/bs17 with `--init-from`, else from scratch.
+   then launches all six runs FROM SCRATCH in parallel (one ~2.5h wave; no `--init-from`
+   chaining off bs8 — against a 6h cap two sequential ~2.4h waves risks the cap). If
+   extraction finishes early and hours remain, re-run bs13/bs17 with `--init-from` then.
 4. If >=4 spare cards for extraction: `scripts/rental/run_extraction.sh eta-check` first
    (178GB AWQ checkpoint, 1-shard sample). Abort slice C (not training) if ETA > 60 min.
-   Else `run_extraction.sh download` then `run_extraction.sh extract extract 1000000`
-   (PP4, `--no-batch`, default 1M tokens ~2h20m + 15-20min load — the bundle's own 2M/~4h40m
-   sizing does not fit the 6h/$17 cap alongside training + download + boot; size the token
-   count down further at call time if less wall-clock remains, and reserve >=30 min at the
-   end for rsync-back + destroy. `--resume` means any stop-point's shards are still usable.
+   Else `run_extraction.sh download` then `run_extraction.sh extract 1000000` (PP4,
+   `--no-batch`, default 1M tokens). **Do not trust a flat ~2h20m estimate** — Gen1x4
+   throughput for PP4's per-step cross-stage hidden-state hop is unmeasured on this
+   topology. Read the extractor's own `[shard 0] ... tok/s` line (~7 min in) and re-plan:
+   120 tok/s -> 2h20m, 80 -> 3h30m, 60 -> 4h40m for 1M tokens. If shard 0 comes in under
+   ~70 tok/s, cut the token target (not the run) — `--resume` checkpoints every shard, so
+   stopping early yields a short clean slice rather than a truncated unusable one. Reserve
+   >=30 min at the end for rsync-back + destroy regardless of how far extraction got.
 5. rsync checkpoints + `acceptance.json` + slice-C shards back to
    `/library/models/specdec-data/vast-2026-09-05/` on the source host.
 6. `vastai destroy instance <ID>`; confirm via `vastai show instances-v1`.

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -1,9 +1,18 @@
 # GLM-5.3-Flash on 8x CMP 170HX (Vast.ai rental) — RUNBOOK
 
-Companion to `notebooks/2026-09-03-glm-5.3-flash-4card-tp4-vllm.ipynb`
-(the reproducibility source of truth) and issue tracking this lane. This
-runbook covers the parts specific to a Vast.ai rental: finding an offer,
-onstart, the full measurement queue, and destroy.
+Read [README.md](README.md) first for what this bundle is and its state.
+This runbook covers the parts specific to a Vast.ai rental: finding an
+offer, onstart, the full measurement queue, and destroy.
+
+The four-card recipe of record is the PP4 + native MTP k=3 lane
+([guide](../../docs/models/glm-5.3-flash.md),
+[notebook](../../notebooks/2026-09-05-glm-5.3-flash-4card-pp4-vllm.ipynb)).
+Sections 1-6 below were written against the earlier TP4 lane
+([notebook](../../notebooks/2026-09-03-glm-5.3-flash-4card-tp4-vllm.ipynb),
+superseded 2026-09-05) and still name the `vllm-glm53-sm80-20260903` image
+and TP4 as "the recipe of record" — on eight cards the point of the queue
+is the topologies four cards cannot answer, so re-pin the image to
+`vllm-glm53-sm80-pp-20260905` and lead with PP4 before renting.
 
 ## 0. Preconditions
 
@@ -138,7 +147,7 @@ vastai show instances   # confirm empty / instance gone
 
 New purpose, same branch/scripts family: parallel drafter training (block_size x lr sweep)
 plus, if the box has >=4 spare 64GB cards, a PP4 slice-C hidden-state extraction. Recipe
-of record comes from the drafter lane's "vast bundle" on `seanphan/pixelml#108`; scripts
+of record comes from the drafter lane's "vast bundle" (tracked privately); scripts
 here are a direct-exec translation (no nested docker — same finding as the inference
 image: no docker binary inside `ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-pp-20260905`).
 
@@ -182,11 +191,11 @@ was ~380GB — workable but far tighter; re-pin to `e03679f1` before renting.)
    ~70 tok/s, cut the token target (not the run) — `--resume` checkpoints every shard, so
    stopping early yields a short clean slice rather than a truncated unusable one. Reserve
    >=30 min at the end for rsync-back + destroy regardless of how far extraction got.
-5. rsync checkpoints + `acceptance.json` + slice-C shards back to
-   `/library/models/specdec-data/vast-2026-09-05/` on the source host.
+5. rsync checkpoints + `acceptance.json` + slice-C shards back to the model library
+   on the source host (`$SRC_DATA_DIR/vast-2026-09-05/`, see `transfer_specdec.sh`).
 6. `vastai destroy instance <ID>`; confirm via `vastai show instances-v1`.
-7. Post spend + per-run alpha vs reference (0.3614) + slice-C size to both `#108` and
-   `#107` — never to public repos (AGENTS.md).
+7. Post spend + per-run alpha vs reference (0.3614) + slice-C size to the private
+   tracking issues — never to public repos (AGENTS.md).
 
 ### Notes
 

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -133,3 +133,55 @@ vastai show instances   # confirm empty / instance gone
 | Each bench phase (gate/prefill/ttft/decode_c1) | 1-5 min |
 | c8_stability (3 rounds) | ~5-10 min |
 | Full queue (steps 0-5, 8 cards) | ~2-3 hours including 3 boots (TP4, PP4, TP8) + 2 replicas |
+
+## 7. Training + PP4 extraction rental (2026-09-05)
+
+New purpose, same branch/scripts family: parallel drafter training (block_size x lr sweep)
+plus, if the box has >=4 spare 64GB cards, a PP4 slice-C hidden-state extraction. Recipe
+of record comes from the drafter lane's "vast bundle" on `seanphan/pixelml#108`; scripts
+here are a direct-exec translation (no nested docker — same finding as the inference
+image: no docker binary inside `ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-pp-20260905`).
+
+Caps: total spend <= $17 (balance ~$18.66), <= 6h instance time, destroy on completion.
+
+### Offer priority (via `find_offer.sh`, always `verified=any`)
+
+1. 10x64GB Gen1x4 (49715704-class, ~$1.61/hr): 4 cards extraction + 6 cards training.
+2. Else 8x64GB Gen2x16 (49884606, $3.29/hr): 4 extraction + 4 training, ~5h max.
+3. Else any 4x64GB offer: training only (skip slice C).
+
+Disk >= 450GB required in all cases (178GB AWQ checkpoint + 82GB slice-C output + 18GB
+training data + headroom).
+
+### Sequence
+
+1. Rent with `scripts/rental/onstart_train.sh` as onstart (torch-import sanity only; no
+   checkpoint pull here — that's extraction-only and gated separately).
+2. From the orchestrating machine (not the rental): run `scripts/rental/transfer_specdec.sh`
+   with `SPECDEC_SOURCE`, `SPECDEC_DEST_HOST`, `SPECDEC_DEST_PORT` set. It does a 1GB rate
+   test each hop, then relays tools tarball (sha256 `5fe08a51...`, commit `a774a82`), sliceB
+   (14GB), target-shared.safetensors (1.9GB), ref-drafter (2.2GB) via a local staging dir
+   (source has no route to the rental). Ends with the mandatory gate:
+   `tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9` then `OK`.
+   **Stop if this string differs — do not train on it.**
+3. On the rental: `scripts/rental/run_training.sh [NUM_GPUS_TRAIN]` — runs the reference
+   band check first (`ref_eval2.py`, must land `IN BAND (~36%)` against alpha 0.3614),
+   then launches bs8-lr{1.5e-4,3e-4} immediately; if >=6 training cards, waits (<=30 min)
+   for bs8 `best.pt` then launches bs13/bs17 with `--init-from`, else from scratch.
+4. If >=4 spare cards for extraction: `scripts/rental/run_extraction.sh eta-check` first
+   (178GB AWQ checkpoint, 1-shard sample). Abort slice C (not training) if ETA > 60 min.
+   Else `run_extraction.sh download` then `run_extraction.sh extract` (2M tokens, PP4,
+   `--no-batch`, ~4h40m + 15-20min load, ~82GB output).
+5. rsync checkpoints + `acceptance.json` + slice-C shards back to
+   `/library/models/specdec-data/vast-2026-09-05/` on the source host.
+6. `vastai destroy instance <ID>`; confirm via `vastai show instances-v1`.
+7. Post spend + per-run alpha vs reference (0.3614) + slice-C size to both `#108` and
+   `#107` — never to public repos (AGENTS.md).
+
+### Notes
+
+- Training data footprint (~18GB) is small; the AWQ checkpoint (178GB) is extraction-only
+  and downloaded directly on the rental via `hf download`, not relayed from the source.
+- `run_training.sh` and `run_extraction.sh` translate the bundle's `docker run --gpus
+  device=N ...` per-card commands into `CUDA_VISIBLE_DEVICES=N` + `nohup` + PID file,
+  consistent with `launch_tp4.sh`/`launch_pp4.sh`/`launch_tp8.sh` above.

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -1,0 +1,121 @@
+# GLM-5.3-Flash on 8x CMP 170HX (Vast.ai rental) — RUNBOOK
+
+Companion to `notebooks/2026-09-03-glm-5.3-flash-4card-tp4-vllm.ipynb`
+(the reproducibility source of truth) and issue tracking this lane. This
+runbook covers the parts specific to a Vast.ai rental: finding an offer,
+onstart, the full measurement queue, and destroy.
+
+## 0. Preconditions
+
+- `vastai` CLI installed and authenticated (`vastai show user` works).
+- Balance covers the planned instance-hours at the offer's `$/hr` with
+  headroom for the hard cap below.
+- Image `ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903` pulls
+  anonymously (`docker manifest inspect <image>` from any machine).
+- Checkpoint `wtdcode/GLM-5.3-Flash-AWQ-W4A16` is public on HF (verified via
+  `curl https://huggingface.co/api/models/wtdcode/GLM-5.3-Flash-AWQ-W4A16`).
+
+## 1. Find an offer
+
+```bash
+scripts/rental/find_offer.sh 8
+```
+
+**`verified=any` is required** — vastai hides unverified hosts by default,
+and every CMP 170HX 8x host seen so far is unverified. Without this flag
+the 8x listings silently disappear (looks like "no inventory" when it
+isn't). Pick the offer with the best `pcie_bw_gbs` (Gen2 x16 > Gen1 x4)
+and enough `disk_gb` (need >= 450 for weights + image + receipts).
+
+## 2. Rent
+
+Rent using the image directly as the instance's container (avoids nested
+docker — the recipe's `docker run` commands in the queue run other
+containers *inside* this one only if the offer's Vast template supports
+docker-in-docker; the club-170hx recipe instead launches `vllm serve`
+processes as additional bind-mounted containers via the onstart script,
+so verify `docker info` works inside the rented container before running
+the queue):
+
+```bash
+vastai create instance <OFFER_ID> \
+  --image ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
+  --disk 450 \
+  --onstart-cmd "$(cat scripts/rental/onstart.sh)"
+```
+
+If the offer's template does not support docker-in-docker, rent a plain
+docker-capable Vast template instead and run the club image manually
+inside it (`docker pull ... && docker run ...` per `launch_tp4.sh` etc.)
+rather than fighting nested docker.
+
+## 3. Checkpoint download gate
+
+The onstart script downloads the 190.8 GB checkpoint and aborts if the
+byte count is short. Before committing to the full queue, watch the
+early transfer rate and project the ETA:
+
+```bash
+# after ~2 min of hf download running, from the instance:
+du -sb /workspace/models/glm53 2>/dev/null
+```
+
+If the projected ETA for the full 190.8 GB exceeds **60 minutes**, abort
+and destroy the instance (bad network draw) rather than burn the clock.
+
+## 4. Run the queue
+
+```bash
+NUM_GPUS=8 bash scripts/rental/run_queue.sh
+```
+
+Steps (see `run_queue.sh` for detail), each gated by `wait_ready` with a
+15 min boot timeout and writing JSON receipts under
+`/workspace/receipts/<step>/`:
+
+0. Preflight (link gen/width, topo, P2P, disk, driver/CUDA).
+1. TP4 recipe of record, cards 0-3 — **mm-profiling flag OFF first**; the
+   step auto-retries WITH `--limit-mm-per-prompt` only if the flag-off
+   boot fails, and records which path worked in `mm-flag-result.txt`.
+   Then: sanity, c=1 x5, prefill 2,900 tok, warm TTFT x3, c=8 x3, context
+   sweep 4k/16k/64k, 20-prompt lossless check, boot time.
+2. TP4 variants: P2P/custom-all-reduce path (only if P2P available), k=2,
+   k=5 — c=1 and c=8 cells only.
+3. PP4 + MTP x5, partition 14/12/12/7, enforce-eager — sanity + c=1 x3 +
+   acceptance-length grep from the log. Decides whether the PP4 breakage
+   seen on the 4x home box is the box or the build.
+4. TP8 across all 8 cards (skipped if `NUM_GPUS<8`), then 2x TP4
+   replicas on separate ports for aggregate c=16 (also skipped if
+   `NUM_GPUS<8`).
+5. Collect: tar receipts + trimmed logs to `/workspace/*.tar.gz`.
+
+Resumable: each step's receipts dir gets a `DONE` marker; re-running
+`run_queue.sh` skips completed steps. Delete a step's `DONE` file to
+force a re-run of just that step.
+
+## 5. Hard rules (abort/destroy triggers)
+
+- Any single step hangs > 30 min.
+- Spend approaches the session's hard cap.
+- Xid, ECC, or driver errors appear in `nvidia-smi` or dmesg.
+- Push whatever receipts exist first, then destroy.
+
+## 6. Collect and destroy
+
+```bash
+scp -P <port> root@<host>:/workspace/glm53-8x170hx-receipts-*.tar.gz .
+# commit receipts to the evidence repo branch (never main), per club-170hx AGENTS.md
+vastai destroy instance <INSTANCE_ID>
+vastai show instances   # confirm empty / instance gone
+```
+
+## Expected times (from the 4x home-box recipe; rental will differ)
+
+| Phase | Expected |
+|---|---|
+| Image pull (if not baked into the rented image) | ~5-10 min (40.6 GB, cached layers likely) |
+| Checkpoint download | measure with 1-shard sample; abort if ETA > 60 min for 190.8 GB |
+| TP4 boot | ~8-10 min (weights load twice: main + MTP draft) |
+| Each bench phase (gate/prefill/ttft/decode_c1) | 1-5 min |
+| c8_stability (3 rounds) | ~5-10 min |
+| Full queue (steps 0-5, 8 cards) | ~2-3 hours including 3 boots (TP4, PP4, TP8) + 2 replicas |

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -29,25 +29,39 @@ and enough `disk_gb` (need >= 450 for weights + image + receipts).
 
 ## 2. Rent
 
-Rent using the image directly as the instance's container (avoids nested
-docker — the recipe's `docker run` commands in the queue run other
-containers *inside* this one only if the offer's Vast template supports
-docker-in-docker; the club-170hx recipe instead launches `vllm serve`
-processes as additional bind-mounted containers via the onstart script,
-so verify `docker info` works inside the rented container before running
-the queue):
+**Decision (confirmed 2026-09-04): no nested docker.** The image has no
+`docker`/`dockerd` binary in it (`docker run --rm --entrypoint /bin/bash
+<image> -c 'which docker dockerd'` returns nothing), so the instance is
+rented with the club-170hx image itself as the instance's container, and
+`vllm serve` is exec'd directly inside it (no `docker run` inside the
+rental). `launch_tp4.sh` / `launch_pp4.sh` / `launch_tp8.sh` and
+`run_queue.sh` already assume this (nohup + PID file, plain log files
+under `/workspace/logs`, not `docker logs`).
+
+**Exact rental command** (offer `49884606` as of 2026-09-04: 8x CMP
+170HX, PCIe Gen2 x16 / 6.4 GB/s, 65.5 GB/card, 512 GB RAM, 3238 GB disk,
+$3.293/hr, driver/CUDA 13.3, verified=false — re-run
+`scripts/rental/find_offer.sh 8` first, since offer IDs are single-use
+and availability changes; use the top `pcie_bw_gbs` row):
 
 ```bash
-vastai create instance <OFFER_ID> \
+vastai create instance 49884606 \
   --image ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
   --disk 450 \
-  --onstart-cmd "$(cat scripts/rental/onstart.sh)"
+  --ssh --direct \
+  --onstart scripts/rental/onstart.sh
 ```
 
-If the offer's template does not support docker-in-docker, rent a plain
-docker-capable Vast template instead and run the club image manually
-inside it (`docker pull ... && docker run ...` per `launch_tp4.sh` etc.)
-rather than fighting nested docker.
+`--onstart <file>` (not `--onstart-cmd "$(cat ...)"`) avoids CLI arg
+length limits — `onstart.sh` is ~90 lines. `--ssh --direct` gives a
+direct SSH endpoint for running `run_queue.sh` interactively and for
+`collect.sh`'s scp-back step (`vastai show instances-v1` / `vastai ssh-url
+<id>` after creation resolves the host/port).
+
+At $3.293/hr the 4.5 h / $17 session cap (2026-09-04 balance-adjusted)
+caps the rental at roughly 4.3 h of wall time before the $ cap binds —
+budget accordingly and destroy the moment the queue ends or the cap
+nears, per the hard rules below.
 
 ## 3. Checkpoint download gate
 

--- a/scripts/rental/RUNBOOK.md
+++ b/scripts/rental/RUNBOOK.md
@@ -159,7 +159,7 @@ training data + headroom).
    checkpoint pull here — that's extraction-only and gated separately).
 2. From the orchestrating machine (not the rental): run `scripts/rental/transfer_specdec.sh`
    with `SPECDEC_SOURCE`, `SPECDEC_DEST_HOST`, `SPECDEC_DEST_PORT` set. It does a 1GB rate
-   test each hop, then relays tools tarball (sha256 `5fe08a51...`, commit `a774a82`), sliceB
+   test each hop, then relays tools tarball (sha256 `1fd9f29b...`, commit `eb1434a8`), sliceB
    (14GB), target-shared.safetensors (1.9GB), ref-drafter (2.2GB) via a local staging dir
    (source has no route to the rental). Ends with the mandatory gate:
    `tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9` then `OK`.
@@ -170,8 +170,11 @@ training data + headroom).
    for bs8 `best.pt` then launches bs13/bs17 with `--init-from`, else from scratch.
 4. If >=4 spare cards for extraction: `scripts/rental/run_extraction.sh eta-check` first
    (178GB AWQ checkpoint, 1-shard sample). Abort slice C (not training) if ETA > 60 min.
-   Else `run_extraction.sh download` then `run_extraction.sh extract` (2M tokens, PP4,
-   `--no-batch`, ~4h40m + 15-20min load, ~82GB output).
+   Else `run_extraction.sh download` then `run_extraction.sh extract extract 1000000`
+   (PP4, `--no-batch`, default 1M tokens ~2h20m + 15-20min load — the bundle's own 2M/~4h40m
+   sizing does not fit the 6h/$17 cap alongside training + download + boot; size the token
+   count down further at call time if less wall-clock remains, and reserve >=30 min at the
+   end for rsync-back + destroy. `--resume` means any stop-point's shards are still usable.
 5. rsync checkpoints + `acceptance.json` + slice-C shards back to
    `/library/models/specdec-data/vast-2026-09-05/` on the source host.
 6. `vastai destroy instance <ID>`; confirm via `vastai show instances-v1`.

--- a/scripts/rental/bench/bench_glm53.py
+++ b/scripts/rental/bench/bench_glm53.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""GLM-5.3-Flash (vLLM sm80) prefill/TTFT/c=1 confirmation harness.
+
+Adapted from the club-170hx 4x-box protocol (results/2026-09-03-glm-5.3-flash-
+vllm-sm80-4gpu/README.md): decode phase is temperature 0.7, 512 output
+tokens, ignore_eos, 5 reps, first rep treated as cold.
+
+Usage:
+    python3 bench_glm53.py --base-url http://127.0.0.1:18098 --model glm-5.3-flash \
+        --out /workspace/receipts/tp4-record gate prefill ttft decode_c1
+"""
+import sys
+import uuid
+
+sys.path.insert(0, __import__("os").path.dirname(__file__))
+from common import Client, base_parser, build_fixture, now, save  # noqa: E402
+
+PREFILL_TOKENS = 2900
+REPS = 3
+
+
+def gate(client, out):
+    ids = client.models()
+    det = [client.completion("The capital of France is", 1) for _ in range(3)]
+    texts = [d.get("text_head") for d in det]
+    rec = {
+        "phase": "gate", "utc": now(), "models": ids, "deterministic_reps": det,
+        "deterministic_identical": len(set(texts)) == 1 and all(d["ok"] for d in det),
+        "verdict": "PASS" if client.model in ids and len(set(texts)) == 1 and all(d["ok"] for d in det) else "FAIL",
+    }
+    save(out, "gate.json", rec)
+    print(rec["verdict"], ids, texts)
+    return rec["verdict"] == "PASS"
+
+
+def prefill(client, out):
+    reps = []
+    for i in range(REPS):
+        prefix = f"[run {uuid.uuid4().hex}] "
+        text, _ = build_fixture(client, PREFILL_TOKENS, prefix)
+        r = client.completion(text, 1)
+        pt = r.get("usage", {}).get("prompt_tokens")
+        r["prefill_tok_s"] = round(pt / r["wall_s"], 2) if r["ok"] and pt else None
+        reps.append(r)
+        print("prefill rep", i, r.get("usage"), r["wall_s"], r.get("prefill_tok_s"), flush=True)
+    ok = [x for x in reps if x["ok"]]
+    rec = {
+        "phase": "uncached_prefill", "utc": now(), "target_prompt_tokens": PREFILL_TOKENS, "max_tokens": 1, "reps": reps,
+        "prompt_tokens_exact": all(x.get("usage", {}).get("prompt_tokens") == PREFILL_TOKENS for x in ok) and len(ok) == REPS,
+        "median_wall_s": sorted(x["wall_s"] for x in ok)[len(ok) // 2] if ok else None,
+        "median_prefill_tok_s": sorted(x["prefill_tok_s"] for x in ok)[len(ok) // 2] if ok else None,
+    }
+    save(out, "prefill.json", rec)
+
+
+def ttft(client, out):
+    import json
+    import time
+    import urllib.request
+
+    text, c = build_fixture(client, PREFILL_TOKENS, "[ttft-fixture] ")
+    client.completion(text, 1)  # prime the prefix cache
+    reps = []
+    for i in range(REPS):
+        body = {"model": client.model, "prompt": text, "max_tokens": 32, "temperature": 0, "stream": True,
+                "stream_options": {"include_usage": True}}
+        req = urllib.request.Request(client.base_url + "/v1/completions", json.dumps(body).encode(),
+                                      {"Content-Type": "application/json"})
+        t0 = time.perf_counter()
+        first = None
+        usage = None
+        ntok = 0
+        err = None
+        try:
+            with urllib.request.urlopen(req, timeout=600) as resp:
+                for line in resp:
+                    line = line.decode().strip()
+                    if not line.startswith("data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if payload == "[DONE]":
+                        break
+                    d = json.loads(payload)
+                    if d.get("choices") and d["choices"][0].get("text"):
+                        if first is None:
+                            first = time.perf_counter() - t0
+                        ntok += 1
+                    if d.get("usage"):
+                        usage = d["usage"]
+        except Exception as e:
+            err = f"{type(e).__name__}: {e}"[:1000]
+        total = time.perf_counter() - t0
+        reps.append({"ok": err is None, "ttft_s": round(first, 4) if first else None, "total_s": round(total, 4),
+                     "stream_chunks_with_text": ntok, "usage": usage, "error": err})
+        print("ttft rep", i, reps[-1], flush=True)
+    ok = [x for x in reps if x["ok"] and x["ttft_s"]]
+    rec = {"phase": "warm_streaming_ttft", "utc": now(), "fixture_tokens": c, "reps": reps,
+           "median_ttft_s": sorted(x["ttft_s"] for x in ok)[len(ok) // 2] if ok else None}
+    save(out, "ttft.json", rec)
+
+
+def decode_c1(client, out):
+    prompts = [
+        "Explain in careful detail how a modern operating system kernel implements virtual memory.",
+        "Write an original short story about a lighthouse keeper.",
+        "Write a complete Python implementation of a red-black tree with insert, delete, and search.",
+        "Describe the full lifecycle of an HTTP request from browser to origin server and back.",
+        "Write a detailed essay on the causes and consequences of the 1973 oil shock.",
+    ]
+    reps = []
+    for i, p in enumerate(prompts):
+        r = client.completion(f"[c1-{uuid.uuid4().hex}] " + p, 512, temperature=0.7, ignore_eos=True)
+        ct = r.get("usage", {}).get("completion_tokens")
+        r["decode_tok_s"] = round(ct / r["wall_s"], 2) if r["ok"] and ct else None
+        r["cold"] = (i == 0)
+        reps.append(r)
+        print("decode rep", i, r.get("usage"), r["wall_s"], r.get("decode_tok_s"), flush=True)
+    ok = [x for x in reps if x["ok"]]
+    warm = [x for x in ok if not x["cold"]]
+    rec = {
+        "phase": "c1_decode_confirm", "utc": now(), "reps": reps,
+        "median_tok_s_warm": sorted(x["decode_tok_s"] for x in warm)[len(warm) // 2] if warm else None,
+        "peak_tok_s_warm": max((x["decode_tok_s"] for x in warm), default=None),
+        "cold_rep_tok_s": reps[0].get("decode_tok_s") if reps else None,
+    }
+    save(out, "decode_c1.json", rec)
+
+
+PHASES = {"gate": gate, "prefill": prefill, "ttft": ttft, "decode_c1": decode_c1}
+
+
+def main():
+    p = base_parser(__doc__)
+    p.add_argument("phases", nargs="*", default=["gate", "prefill", "ttft", "decode_c1"], choices=list(PHASES))
+    args = p.parse_args()
+    client = Client(args.base_url, args.model)
+    for ph in args.phases:
+        PHASES[ph](client, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rental/bench/c8_stability.py
+++ b/scripts/rental/bench/c8_stability.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""c=8 aggregate stability check: 3 rounds of 8 concurrent requests.
+
+Usage:
+    python3 c8_stability.py --base-url http://127.0.0.1:18098 --model glm-5.3-flash \
+        --out /workspace/receipts/tp4-record --concurrency 8 --rounds 3
+"""
+import json
+import os
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+sys.path.insert(0, os.path.dirname(__file__))
+from common import Client, base_parser, build_fixture, save  # noqa: E402
+
+PROMPT_TOKENS = 2900
+OUT_TOKENS = 256
+
+
+def one_request(client, i, round_tag):
+    nonce = f"[{round_tag}-{i}-{uuid.uuid4().hex}] "
+    text, _ = build_fixture(client, PROMPT_TOKENS, nonce)
+    t0 = time.perf_counter()
+    r = client.completion(text, OUT_TOKENS, temperature=0.7, ignore_eos=True)
+    dt = time.perf_counter() - t0
+    if r["ok"]:
+        return {"ok": True, "wall_s": round(dt, 3), "completion_tokens": r["usage"]["completion_tokens"]}
+    return {"ok": False, "wall_s": round(dt, 3), "error": r.get("error")}
+
+
+def main():
+    p = base_parser(__doc__)
+    p.add_argument("--concurrency", type=int, default=8)
+    p.add_argument("--rounds", type=int, default=3)
+    args = p.parse_args()
+    client = Client(args.base_url, args.model)
+
+    results = []
+    for rnd in range(1, args.rounds + 1):
+        t0 = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+            res = list(ex.map(lambda i: one_request(client, i, f"r{rnd}"), range(args.concurrency)))
+        wall = time.perf_counter() - t0
+        ok = [r for r in res if r["ok"]]
+        toks = sum(r["completion_tokens"] for r in ok)
+        rec = {
+            "round": rnd, "concurrency": args.concurrency, "succeeded": len(ok), "failed": args.concurrency - len(ok),
+            "wall_s": round(wall, 3), "aggregate_tok_s": round(toks / wall, 2) if wall > 0 else None,
+            "errors": [r.get("error") for r in res if not r["ok"]],
+        }
+        results.append(rec)
+        print(json.dumps(rec), flush=True)
+
+    save(args.out, f"c{args.concurrency}_stability.json", results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rental/bench/common.py
+++ b/scripts/rental/bench/common.py
@@ -1,0 +1,107 @@
+"""Shared HTTP/tokenizer helpers for the GLM-5.3-Flash rental bench scripts."""
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+
+def now():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def base_parser(description):
+    p = argparse.ArgumentParser(description=description)
+    p.add_argument("--base-url", default=os.environ.get("GLM_URL", "http://127.0.0.1:18098"))
+    p.add_argument("--model", default=os.environ.get("GLM_MODEL_NAME", "glm-5.3-flash"))
+    p.add_argument("--out", default=os.environ.get("GLM_OUT", "."))
+    return p
+
+
+class Client:
+    def __init__(self, base_url, model):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def post(self, path, body, timeout=1800):
+        req = urllib.request.Request(
+            self.base_url + path, json.dumps(body).encode(), {"Content-Type": "application/json"}
+        )
+        return urllib.request.urlopen(req, timeout=timeout)
+
+    def completion(self, prompt, max_tokens, temperature=0, ignore_eos=False, timeout=1800, seed=None):
+        body = {"model": self.model, "prompt": prompt, "max_tokens": max_tokens, "temperature": temperature}
+        if ignore_eos:
+            body["ignore_eos"] = True
+        if seed is not None:
+            body["seed"] = seed
+        t0 = time.perf_counter()
+        try:
+            r = json.load(self.post("/v1/completions", body, timeout))
+            dt = time.perf_counter() - t0
+            return {
+                "ok": True,
+                "wall_s": round(dt, 4),
+                "usage": r["usage"],
+                "text_head": r["choices"][0]["text"][:80],
+                "text": r["choices"][0]["text"],
+                "finish_reason": r["choices"][0].get("finish_reason"),
+            }
+        except urllib.error.HTTPError as e:
+            return {"ok": False, "wall_s": round(time.perf_counter() - t0, 4),
+                     "error": f"HTTP {e.code}: {e.read().decode(errors='replace')[:2000]}"}
+        except Exception as e:
+            return {"ok": False, "wall_s": round(time.perf_counter() - t0, 4), "error": f"{type(e).__name__}: {e}"[:2000]}
+
+    def tokenize(self, text):
+        r = json.load(self.post("/tokenize", {"model": self.model, "prompt": text}, 120))
+        return r["count"]
+
+    def models(self):
+        r = json.load(urllib.request.urlopen(self.base_url + "/v1/models", timeout=60))
+        return [m["id"] for m in r["data"]]
+
+
+BASE_FIXTURE = (
+    "The following is a technical reference on distributed systems. Section {n}: consensus protocols. "
+    "A replicated state machine applies a deterministic sequence of commands to identical copies of state on every node. "
+    "Leader election chooses one node to order commands; followers acknowledge log entries; commitment requires a quorum. "
+    "Failure detectors use heartbeats and timeouts; network partitions cause split votes; term numbers resolve stale leaders. "
+)
+
+
+def build_fixture(client, target, prefix=""):
+    body = ""
+    n = 0
+    while client.tokenize(prefix + body) < target:
+        n += 1
+        body += BASE_FIXTURE.format(n=n)
+    words = body.split(" ")
+    lo, hi = 0, len(words)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if client.tokenize(prefix + " ".join(words[:mid])) < target:
+            lo = mid + 1
+        else:
+            hi = mid
+    text = prefix + " ".join(words[:lo])
+    c = client.tokenize(text)
+    tries = 0
+    while c != target and tries < 40:
+        tries += 1
+        if c > target:
+            text = text[:-1]
+        else:
+            text += " a"
+        c = client.tokenize(text)
+    return text, c
+
+
+def save(out_dir, name, obj):
+    os.makedirs(out_dir, exist_ok=True)
+    p = os.path.join(out_dir, name)
+    with open(p + ".tmp", "w") as f:
+        json.dump(obj, f, indent=2)
+    os.replace(p + ".tmp", p)
+    print("saved", p, flush=True)

--- a/scripts/rental/bench/context_sweep.py
+++ b/scripts/rental/bench/context_sweep.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Prefill-tok/s context-length sweep: 4k / 16k / 64k tokens, 3 reps each.
+
+Usage:
+    python3 context_sweep.py --base-url http://127.0.0.1:18098 --model glm-5.3-flash \
+        --out /workspace/receipts/tp4-record --lengths 4096 16384 65536 --reps 3
+"""
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.dirname(__file__))
+from common import Client, base_parser, build_fixture, now, save  # noqa: E402
+
+
+def main():
+    p = base_parser(__doc__)
+    p.add_argument("--lengths", type=int, nargs="+", default=[4096, 16384, 65536])
+    p.add_argument("--reps", type=int, default=3)
+    args = p.parse_args()
+    client = Client(args.base_url, args.model)
+
+    cells = []
+    for target in args.lengths:
+        reps = []
+        for i in range(args.reps):
+            prefix = f"[ctx-{target}-{uuid.uuid4().hex}] "
+            text, exact = build_fixture(client, target, prefix)
+            r = client.completion(text, 1)
+            pt = r.get("usage", {}).get("prompt_tokens")
+            r["prefill_tok_s"] = round(pt / r["wall_s"], 2) if r["ok"] and pt else None
+            r["fixture_tokens_exact"] = exact
+            reps.append(r)
+            print(f"ctx={target} rep {i}", r.get("usage"), r["wall_s"], r.get("prefill_tok_s"), flush=True)
+        ok = [x for x in reps if x["ok"]]
+        cells.append({
+            "target_tokens": target, "reps": reps,
+            "median_prefill_tok_s": sorted(x["prefill_tok_s"] for x in ok)[len(ok) // 2] if ok else None,
+        })
+
+    rec = {"phase": "context_sweep", "utc": now(), "cells": cells}
+    save(args.out, "context_sweep.json", rec)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rental/bench/lossless_check.py
+++ b/scripts/rental/bench/lossless_check.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""20-prompt greedy (temperature=0) determinism/lossless sanity check with
+speculative decoding (MTP) enabled. Each prompt is run twice; PASS requires
+byte-identical output both times (greedy + spec should be exactly lossless).
+
+Usage:
+    python3 lossless_check.py --base-url http://127.0.0.1:18098 --model glm-5.3-flash \
+        --out /workspace/receipts/tp4-record
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from common import Client, base_parser, now, save  # noqa: E402
+
+PROMPTS = [
+    "Summarize the plot of Hamlet in three sentences.",
+    "Write a haiku about the ocean.",
+    "What is the capital of Mongolia?",
+    "Explain photosynthesis to a five-year-old.",
+    "List the first ten prime numbers.",
+    "Write a SQL query that selects the top 5 customers by total order value.",
+    "Translate 'good morning' into French, Spanish, and Japanese.",
+    "What year did the Berlin Wall fall?",
+    "Write a regex that matches a US phone number.",
+    "Explain the difference between TCP and UDP.",
+    "Write a function in Python that reverses a linked list.",
+    "What is the boiling point of water at sea level in Celsius?",
+    "Give three synonyms for 'happy'.",
+    "Explain what a hash table is.",
+    "Write a short limerick about a cat.",
+    "What is the chemical formula for table salt?",
+    "Describe the water cycle in two sentences.",
+    "Write a bash one-liner that counts lines in a file.",
+    "What is the speed of light in a vacuum, in meters per second?",
+    "Name the planets of the solar system in order from the sun.",
+]
+
+
+def main():
+    p = base_parser(__doc__)
+    args = p.parse_args()
+    client = Client(args.base_url, args.model)
+
+    reps = []
+    n_match = 0
+    for i, prompt in enumerate(PROMPTS):
+        r1 = client.completion(prompt, 128, temperature=0, seed=42)
+        r2 = client.completion(prompt, 128, temperature=0, seed=42)
+        match = r1.get("ok") and r2.get("ok") and r1.get("text") == r2.get("text")
+        n_match += int(match)
+        reps.append({
+            "prompt": prompt, "match": match,
+            "text1_head": r1.get("text_head"), "text2_head": r2.get("text_head"),
+            "ok1": r1.get("ok"), "ok2": r2.get("ok"),
+        })
+        print(f"[{i:02d}] match={match}", flush=True)
+
+    rec = {
+        "phase": "lossless_check", "utc": now(), "n_prompts": len(PROMPTS), "n_match": n_match,
+        "verdict": "PASS" if n_match == len(PROMPTS) else "FAIL", "reps": reps,
+    }
+    save(args.out, "lossless_check.json", rec)
+    print(rec["verdict"], f"{n_match}/{len(PROMPTS)} identical")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rental/collect.sh
+++ b/scripts/rental/collect.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Tar receipts + trimmed container logs, ready to scp back and commit to the
+# evidence branch. Does not push anything itself.
+set -euo pipefail
+RECEIPTS_ROOT="${RECEIPTS_ROOT:-/workspace/receipts}"
+OUT_TAR="${OUT_TAR:-/workspace/glm53-8x170hx-receipts-$(date -u +%Y%m%dT%H%M%SZ).tar.gz}"
+
+mkdir -p /workspace/logs
+for c in glm53-tp4 glm53-tp4a glm53-tp4b glm53-pp4 glm53-tp8; do
+  docker logs "$c" > "/workspace/logs/${c}.log" 2>&1 || true
+  tail -c 2000000 "/workspace/logs/${c}.log" > "/workspace/logs/${c}.trimmed.log" 2>/dev/null || true
+done
+
+tar -czf "$OUT_TAR" -C /workspace receipts logs
+echo "[collect] wrote $OUT_TAR"
+du -h "$OUT_TAR"
+echo "[collect] scp back with:"
+echo "  scp -P <port> root@<host>:$OUT_TAR ."

--- a/scripts/rental/collect.sh
+++ b/scripts/rental/collect.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# Tar receipts + trimmed container logs, ready to scp back and commit to the
-# evidence branch. Does not push anything itself.
+# Tar receipts + trimmed logs, ready to scp back and commit to the evidence
+# branch. Does not push anything itself. Direct-exec: logs are already
+# plain files under /workspace/logs (no docker logs to pull).
 set -euo pipefail
 RECEIPTS_ROOT="${RECEIPTS_ROOT:-/workspace/receipts}"
+LOGDIR="${LOGDIR:-/workspace/logs}"
 OUT_TAR="${OUT_TAR:-/workspace/glm53-8x170hx-receipts-$(date -u +%Y%m%dT%H%M%SZ).tar.gz}"
 
-mkdir -p /workspace/logs
-for c in glm53-tp4 glm53-tp4a glm53-tp4b glm53-pp4 glm53-tp8; do
-  docker logs "$c" > "/workspace/logs/${c}.log" 2>&1 || true
-  tail -c 2000000 "/workspace/logs/${c}.log" > "/workspace/logs/${c}.trimmed.log" 2>/dev/null || true
+mkdir -p "$LOGDIR"
+for f in "$LOGDIR"/*.log; do
+  [[ -f "$f" ]] || continue
+  tail -c 2000000 "$f" > "${f%.log}.trimmed.log" 2>/dev/null || true
 done
 
 tar -czf "$OUT_TAR" -C /workspace receipts logs

--- a/scripts/rental/find_offer.sh
+++ b/scripts/rental/find_offer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Re-check the Vast.ai market for CMP 170HX offers, sorted by PCIe bandwidth
+# (gen x width, best first). Requires the vastai CLI to be installed and
+# authenticated (vastai set api-key ...).
+#
+# IMPORTANT: verified=any is required — vastai hides unverified hosts by
+# default, and the only CMP 170HX 8x hosts seen so far are unverified.
+# Without this flag, 8x offers silently disappear from the listing.
+#
+# Usage: scripts/rental/find_offer.sh [min_gpus]
+set -euo pipefail
+MIN_GPUS="${1:-4}"
+
+command -v vastai >/dev/null 2>&1 || { echo "vastai CLI not found; pip install vastai" >&2; exit 1; }
+
+echo "# CMP 170HX offers, num_gpus>=${MIN_GPUS}, verified=any, sorted by PCIe bandwidth (desc)"
+vastai search offers "gpu_name=CMP_170HX num_gpus>=${MIN_GPUS} verified=any" \
+  -o 'pcie_bw-' \
+  --raw \
+| python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+if not rows:
+    print("(no offers currently match)")
+    sys.exit(0)
+cols = ["id", "num_gpus", "gpu_ram", "pci_gen", "gpu_lanes", "pcie_bw", "disk_space", "dph_total", "reliability2"]
+labels = ["id", "gpus", "gpu_ram_gb", "pci_gen", "lanes", "pcie_bw_gbs", "disk_gb", "usd_per_hr", "reliability"]
+print("  ".join(l.rjust(11) for l in labels))
+for r in rows:
+    vals = []
+    for c in cols:
+        v = r.get(c)
+        if isinstance(v, float):
+            v = round(v, 2)
+        vals.append(str(v))
+    print("  ".join(v.rjust(11) for v in vals))
+'

--- a/scripts/rental/launch_pp4.sh
+++ b/scripts/rental/launch_pp4.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
-# PP4 + MTP x5, partition 14/12/12/7, enforce-eager. This decides whether the
-# PP4 breakage seen on our 4x box (3.35 tok/s, acceptance 1.34, repetitive
-# greedy output) is our box or the build.
+# PP4 + MTP x5, partition 14/12/12/7, enforce-eager. Direct-exec, no docker.
 set -euo pipefail
 PORT="${PORT:-18099}"
 MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
 NAME="${NAME:-glm53-pp4}"
 DEVICES="${DEVICES:-0,1,2,3}"
+LOGDIR="${LOGDIR:-/workspace/logs}"
+PIDDIR="${PIDDIR:-/workspace/pids}"
+mkdir -p "$LOGDIR" "$PIDDIR"
 
-docker rm -f "$NAME" >/dev/null 2>&1 || true
-docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
-  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
-  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
-  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
-  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
-  -e VLLM_PP_LAYER_PARTITION="14,12,12,7" \
-  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
-  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
-  vllm serve /model --served-model-name glm-5.3-flash \
+if [[ -f "$PIDDIR/$NAME.pid" ]]; then
+  kill "$(cat "$PIDDIR/$NAME.pid")" 2>/dev/null || true
+  sleep 2
+fi
+
+CUDA_VISIBLE_DEVICES="$DEVICES" \
+HF_HUB_OFFLINE=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_ENGINE_READY_TIMEOUT_S=1800 VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+NCCL_VERSION=2.28.3-1 TORCH_CUDA_ARCH_LIST=8.0 VLLM_TARGET_DEVICE=cuda \
+VLLM_PP_LAYER_PARTITION="14,12,12,7" \
+nohup vllm serve "$MODEL_DIR" --served-model-name glm-5.3-flash \
   --pipeline-parallel-size 4 --enforce-eager \
   --max-model-len 524288 --gpu-memory-utilization 0.92 \
   --max-num-seqs 16 --max-num-batched-tokens 8192 --enable-prefix-caching \
   --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
-  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45 \
+  --port "$PORT" > "$LOGDIR/$NAME.log" 2>&1 &
+echo $! > "$PIDDIR/$NAME.pid"
 
-echo "[launch_pp4] container $NAME up on port $PORT, PP4 partition 14/12/12/7, k=5, enforce-eager"
+echo "[launch_pp4] pid $(cat "$PIDDIR/$NAME.pid") on port $PORT, PP4 partition 14/12/12/7, k=5, enforce-eager"

--- a/scripts/rental/launch_pp4.sh
+++ b/scripts/rental/launch_pp4.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PP4 + MTP x5, partition 14/12/12/7, enforce-eager. This decides whether the
+# PP4 breakage seen on our 4x box (3.35 tok/s, acceptance 1.34, repetitive
+# greedy output) is our box or the build.
+set -euo pipefail
+PORT="${PORT:-18099}"
+MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
+NAME="${NAME:-glm53-pp4}"
+DEVICES="${DEVICES:-0,1,2,3}"
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
+  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
+  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
+  -e VLLM_PP_LAYER_PARTITION="14,12,12,7" \
+  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
+  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
+  vllm serve /model --served-model-name glm-5.3-flash \
+  --pipeline-parallel-size 4 --enforce-eager \
+  --max-model-len 524288 --gpu-memory-utilization 0.92 \
+  --max-num-seqs 16 --max-num-batched-tokens 8192 --enable-prefix-caching \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45
+
+echo "[launch_pp4] container $NAME up on port $PORT, PP4 partition 14/12/12/7, k=5, enforce-eager"

--- a/scripts/rental/launch_tp4.sh
+++ b/scripts/rental/launch_tp4.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# TP4 recipe of record, cards 0-3. Env overrides: K (spec depth, default 3),
-# NO_CUSTOM_AR=0 to re-enable custom all-reduce (P2P path test), PORT (default 18098).
+# TP4 recipe of record, cards 0-3, direct-exec (no nested docker — the
+# rental IS the club-170hx image container already). Env overrides:
+# K (spec depth, default 3), NO_CUSTOM_AR=0 to re-enable custom all-reduce
+# (P2P path test), PORT (default 18098), DEVICES (default 0,1,2,3).
 set -euo pipefail
 K="${K:-3}"
 PORT="${PORT:-18098}"
@@ -8,14 +10,23 @@ NO_CUSTOM_AR="${NO_CUSTOM_AR:-1}"
 MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
 NAME="${NAME:-glm53-tp4}"
 DEVICES="${DEVICES:-0,1,2,3}"
-EXTRA_MM_FLAG="${EXTRA_MM_FLAG:-}"   # set to '--limit-mm-per-prompt {"image": 0, "video": 0}' if mm-profiling crashes
+EXTRA_MM_FLAG="${EXTRA_MM_FLAG:-}"   # e.g. '--limit-mm-per-prompt {"image": 0, "video": 0}'
+LOGDIR="${LOGDIR:-/workspace/logs}"
+PIDDIR="${PIDDIR:-/workspace/pids}"
+mkdir -p "$LOGDIR" "$PIDDIR"
 
-ARGS=(--tensor-parallel-size 4 --max-model-len 524288 \
+if [[ -f "$PIDDIR/$NAME.pid" ]]; then
+  kill "$(cat "$PIDDIR/$NAME.pid")" 2>/dev/null || true
+  sleep 2
+fi
+
+ARGS=(--served-model-name glm-5.3-flash --tensor-parallel-size 4 --max-model-len 524288 \
   --gpu-memory-utilization 0.92 --max-num-seqs 16 \
   --max-num-batched-tokens 8192 --enable-prefix-caching \
   --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,16],"max_cudagraph_capture_size":16}' \
   --speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${K}}" \
-  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45)
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45 \
+  --port "$PORT")
 
 if [[ "$NO_CUSTOM_AR" == "1" ]]; then
   ARGS+=(--disable-custom-all-reduce)
@@ -24,14 +35,11 @@ if [[ -n "$EXTRA_MM_FLAG" ]]; then
   ARGS+=($EXTRA_MM_FLAG)
 fi
 
-docker rm -f "$NAME" >/dev/null 2>&1 || true
-docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
-  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
-  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
-  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
-  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
-  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
-  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
-  vllm serve /model --served-model-name glm-5.3-flash "${ARGS[@]}"
+CUDA_VISIBLE_DEVICES="$DEVICES" \
+HF_HUB_OFFLINE=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_ENGINE_READY_TIMEOUT_S=1800 VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+NCCL_VERSION=2.28.3-1 TORCH_CUDA_ARCH_LIST=8.0 VLLM_TARGET_DEVICE=cuda \
+nohup vllm serve "$MODEL_DIR" "${ARGS[@]}" > "$LOGDIR/$NAME.log" 2>&1 &
+echo $! > "$PIDDIR/$NAME.pid"
 
-echo "[launch_tp4] container $NAME up on port $PORT, k=$K, custom-all-reduce-disabled=$NO_CUSTOM_AR, devices=$DEVICES"
+echo "[launch_tp4] pid $(cat "$PIDDIR/$NAME.pid") on port $PORT, k=$K, custom-all-reduce-disabled=$NO_CUSTOM_AR, devices=$DEVICES"

--- a/scripts/rental/launch_tp4.sh
+++ b/scripts/rental/launch_tp4.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# TP4 recipe of record, cards 0-3. Env overrides: K (spec depth, default 3),
+# NO_CUSTOM_AR=0 to re-enable custom all-reduce (P2P path test), PORT (default 18098).
+set -euo pipefail
+K="${K:-3}"
+PORT="${PORT:-18098}"
+NO_CUSTOM_AR="${NO_CUSTOM_AR:-1}"
+MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
+NAME="${NAME:-glm53-tp4}"
+DEVICES="${DEVICES:-0,1,2,3}"
+EXTRA_MM_FLAG="${EXTRA_MM_FLAG:-}"   # set to '--limit-mm-per-prompt {"image": 0, "video": 0}' if mm-profiling crashes
+
+ARGS=(--tensor-parallel-size 4 --max-model-len 524288 \
+  --gpu-memory-utilization 0.92 --max-num-seqs 16 \
+  --max-num-batched-tokens 8192 --enable-prefix-caching \
+  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,16],"max_cudagraph_capture_size":16}' \
+  --speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${K}}" \
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45)
+
+if [[ "$NO_CUSTOM_AR" == "1" ]]; then
+  ARGS+=(--disable-custom-all-reduce)
+fi
+if [[ -n "$EXTRA_MM_FLAG" ]]; then
+  ARGS+=($EXTRA_MM_FLAG)
+fi
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
+  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
+  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
+  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
+  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
+  vllm serve /model --served-model-name glm-5.3-flash "${ARGS[@]}"
+
+echo "[launch_tp4] container $NAME up on port $PORT, k=$K, custom-all-reduce-disabled=$NO_CUSTOM_AR, devices=$DEVICES"

--- a/scripts/rental/launch_tp8.sh
+++ b/scripts/rental/launch_tp8.sh
@@ -1,27 +1,33 @@
 #!/usr/bin/env bash
-# TP8 across all 8 cards, k=3.
+# TP8 across all 8 cards, k=3. Direct-exec, no docker.
 set -euo pipefail
 PORT="${PORT:-18098}"
 K="${K:-3}"
 MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
 NAME="${NAME:-glm53-tp8}"
 DEVICES="${DEVICES:-0,1,2,3,4,5,6,7}"
+LOGDIR="${LOGDIR:-/workspace/logs}"
+PIDDIR="${PIDDIR:-/workspace/pids}"
+mkdir -p "$LOGDIR" "$PIDDIR"
 
-docker rm -f "$NAME" >/dev/null 2>&1 || true
-docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
-  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
-  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
-  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
-  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
-  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
-  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
-  vllm serve /model --served-model-name glm-5.3-flash \
+if [[ -f "$PIDDIR/$NAME.pid" ]]; then
+  kill "$(cat "$PIDDIR/$NAME.pid")" 2>/dev/null || true
+  sleep 2
+fi
+
+CUDA_VISIBLE_DEVICES="$DEVICES" \
+HF_HUB_OFFLINE=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_ENGINE_READY_TIMEOUT_S=1800 VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+NCCL_VERSION=2.28.3-1 TORCH_CUDA_ARCH_LIST=8.0 VLLM_TARGET_DEVICE=cuda \
+nohup vllm serve "$MODEL_DIR" --served-model-name glm-5.3-flash \
   --tensor-parallel-size 8 --max-model-len 524288 \
   --gpu-memory-utilization 0.92 --max-num-seqs 16 \
   --max-num-batched-tokens 8192 --enable-prefix-caching \
   --disable-custom-all-reduce \
   --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,16],"max_cudagraph_capture_size":16}' \
   --speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${K}}" \
-  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45 \
+  --port "$PORT" > "$LOGDIR/$NAME.log" 2>&1 &
+echo $! > "$PIDDIR/$NAME.pid"
 
-echo "[launch_tp8] container $NAME up on port $PORT, TP8, k=$K"
+echo "[launch_tp8] pid $(cat "$PIDDIR/$NAME.pid") on port $PORT, TP8, k=$K"

--- a/scripts/rental/launch_tp8.sh
+++ b/scripts/rental/launch_tp8.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# TP8 across all 8 cards, k=3.
+set -euo pipefail
+PORT="${PORT:-18098}"
+K="${K:-3}"
+MODEL_DIR="${MODEL_DIR:-/workspace/models/glm53}"
+NAME="${NAME:-glm53-tp8}"
+DEVICES="${DEVICES:-0,1,2,3,4,5,6,7}"
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --name "$NAME" --gpus "\"device=${DEVICES}\"" \
+  --shm-size 16g --ipc=host -p "127.0.0.1:${PORT}:8000" \
+  -e HF_HUB_OFFLINE=1 -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=1800 -e VLLM_ENGINE_ITERATION_TIMEOUT_S=1800 \
+  -e NCCL_VERSION=2.28.3-1 -e TORCH_CUDA_ARCH_LIST=8.0 -e VLLM_TARGET_DEVICE=cuda \
+  --mount type=bind,src="$MODEL_DIR",dst=/model,readonly \
+  ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903 \
+  vllm serve /model --served-model-name glm-5.3-flash \
+  --tensor-parallel-size 8 --max-model-len 524288 \
+  --gpu-memory-utilization 0.92 --max-num-seqs 16 \
+  --max-num-batched-tokens 8192 --enable-prefix-caching \
+  --disable-custom-all-reduce \
+  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,16],"max_cudagraph_capture_size":16}' \
+  --speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${K}}" \
+  --enable-auto-tool-choice --tool-call-parser glm47 --reasoning-parser glm45
+
+echo "[launch_tp8] container $NAME up on port $PORT, TP8, k=$K"

--- a/scripts/rental/onstart.sh
+++ b/scripts/rental/onstart.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Vast.ai onstart script: 8x (or NUM_GPUS) CMP 170HX box for GLM-5.3-Flash vLLM sm80.
+# Assumes the instance is created with --image ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903
+# so this script runs INSIDE that container as PID 1's onstart hook (no nested docker).
+# Installs nothing the image doesn't already have. Idempotent: safe to re-run.
+set -euo pipefail
+
+IMAGE="ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903"
+CKPT_REPO="wtdcode/GLM-5.3-Flash-AWQ-W4A16"
+CKPT_REVISION="abd7b07719111f137e1de8a0c1b7e01c11b74d1a"
+CKPT_BYTES_EXPECTED=190843146533
+MODEL_DIR="/workspace/models/glm53"
+RECEIPTS="/workspace/receipts/preflight"
+
+mkdir -p "$RECEIPTS" "$MODEL_DIR"
+
+echo "[onstart] $(date -u +%FT%TZ) image=$IMAGE"
+
+# --- Preflight receipts (no GPU state changes beyond power cap below) ---
+nvidia-smi --query-gpu=index,name,memory.total,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max,driver_version --format=csv \
+  | tee "$RECEIPTS/nvidia-smi-query.csv"
+nvidia-smi topo -m | tee "$RECEIPTS/topo-m.txt"
+nvidia-smi topo -p2p r | tee "$RECEIPTS/topo-p2p-r.txt" || echo "[onstart] topo -p2p r not supported" | tee -a "$RECEIPTS/topo-p2p-r.txt"
+nvcc --version 2>/dev/null | tee "$RECEIPTS/nvcc-version.txt" || true
+
+# --- Power cap: 180 W per card, best-effort (some Vast hosts block this) ---
+NUM_GPUS_DETECTED=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+echo "[onstart] detected $NUM_GPUS_DETECTED GPUs"
+for i in $(seq 0 $((NUM_GPUS_DETECTED - 1))); do
+  nvidia-smi -i "$i" -pl 180 2>&1 | tee -a "$RECEIPTS/power-cap.log" || \
+    echo "[onstart] WARNING: could not set power cap on GPU $i (host may not permit it)" | tee -a "$RECEIPTS/power-cap.log"
+done
+
+# --- Image is already running as the container; verify tag/digest in-place ---
+{
+  echo "image_ref=$IMAGE"
+  python3 -c "import json;print(json.dumps({'python':__import__('sys').version}))" 2>/dev/null || true
+  vllm --version 2>&1 | tail -3
+  hf --version 2>&1
+} | tee "$RECEIPTS/image-versions.txt"
+
+# --- Checkpoint download with shard-size gate ---
+echo "[onstart] downloading $CKPT_REPO@$CKPT_REVISION to $MODEL_DIR"
+t0=$(date +%s)
+hf download "$CKPT_REPO" --revision "$CKPT_REVISION" --local-dir "$MODEL_DIR" --max-workers 16 \
+  | tee "$RECEIPTS/hf-download.log"
+t1=$(date +%s)
+
+actual_bytes=$(find "$MODEL_DIR" -type f -exec stat -c '%s' {} + 2>/dev/null | awk '{s+=$1} END {print s+0}')
+echo "[onstart] checkpoint download took $((t1 - t0))s, ${actual_bytes} bytes (expected ${CKPT_BYTES_EXPECTED})"
+if [[ "$actual_bytes" -lt "$((CKPT_BYTES_EXPECTED - 1048576))" ]]; then
+  echo "[onstart] ABORT: checkpoint incomplete ($actual_bytes < $CKPT_BYTES_EXPECTED - 1MiB slack)" | tee -a "$RECEIPTS/hf-download.log"
+  exit 1
+fi
+echo "{\"expected_bytes\": $CKPT_BYTES_EXPECTED, \"actual_bytes\": $actual_bytes, \"download_s\": $((t1 - t0))}" \
+  > "$RECEIPTS/checkpoint-verify.json"
+
+echo "[onstart] done. Next: run_queue.sh"

--- a/scripts/rental/onstart.sh
+++ b/scripts/rental/onstart.sh
@@ -31,7 +31,8 @@ for i in $(seq 0 $((NUM_GPUS_DETECTED - 1))); do
     echo "[onstart] WARNING: could not set power cap on GPU $i (host may not permit it)" | tee -a "$RECEIPTS/power-cap.log"
 done
 
-# --- Image is already running as the container; verify tag/digest in-place ---
+# --- No nested docker: the instance itself runs $IMAGE as its container ---
+# (rented with --image "$IMAGE"). Verify the installed tool versions in place.
 {
   echo "image_ref=$IMAGE"
   python3 -c "import json;print(json.dumps({'python':__import__('sys').version}))" 2>/dev/null || true

--- a/scripts/rental/onstart_train.sh
+++ b/scripts/rental/onstart_train.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Vast.ai onstart script: CMP 170HX box rented for drafter TRAINING (+ optional PP4
+# slice-C extraction), not inference. Companion to onstart.sh (the inference variant).
+# Assumes the instance is created with --image ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-pp-20260905
+# so this script runs INSIDE that container directly (no nested docker, no docker binary
+# in the image — confirmed on the sibling inference image; per-card work below uses
+# nohup + PID files, not `docker run`, translating the drafter lane's bundle 1:1).
+set -euo pipefail
+
+DATA=/data
+TOOLS=/data/tools
+OUT=/out
+RECEIPTS=/workspace/receipts/preflight
+mkdir -p "$DATA" "$OUT" "$RECEIPTS"
+
+echo "[onstart] $(date -u +%FT%TZ) training/extraction rental"
+
+# --- Preflight receipts ---
+nvidia-smi --query-gpu=index,name,memory.total,pcie.link.gen.current,pcie.link.width.current,driver_version --format=csv \
+  | tee "$RECEIPTS/nvidia-smi-query.csv"
+NUM_GPUS_DETECTED=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+echo "[onstart] detected $NUM_GPUS_DETECTED GPUs"
+
+# --- Torch import sanity (this image has no pip install step; must already work) ---
+python3 -c "import torch, numpy, safetensors; print('torch', torch.__version__, 'cuda', torch.cuda.is_available())" \
+  | tee "$RECEIPTS/torch-import.txt"
+
+echo "[onstart] done. Data transfer happens from the orchestrating machine (transfer_specdec.sh)."
+echo "[onstart] After transfer lands: verify_manifest.py /data/sliceB 400000 MUST print"
+echo "[onstart]   'tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9' then 'OK'"
+echo "[onstart] before any training run starts. Do not proceed if it differs."

--- a/scripts/rental/run_extraction.sh
+++ b/scripts/rental/run_extraction.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-# Direct-exec translation of the drafter lane's slice-C (2M token) PP4 extraction command
-# (seanphan/pixelml#108). Only run this if >=4 spare cards exist AND the time budget allows:
-# measured 120 tok/s on 4x170HX PP4 -> 2,000,000/120 =~ 4h40m plus ~15-20min weight load.
+# Direct-exec translation of the drafter lane's slice-C PP4 extraction command
+# (seanphan/pixelml#108). Only run this if >=4 spare cards exist AND the time budget allows.
+# Measured 120 tok/s on 4x170HX PP4. The bundle's own sizing (2M tokens, ~4h40m) does NOT
+# fit inside the 6h/$17 rental cap alongside training + AWQ download + boot, so this script
+# defaults to 1M tokens (~2h20m of compute) instead — size TOKENS down further at call time
+# if less wall-clock is actually left; reserve >=30 min at the end for rsync-back + destroy.
 # Requires the 178 GB AWQ checkpoint at /model — download it first with run_extraction.sh
 # download-only, check the ETA gate, THEN run extraction (abort extraction, not training,
 # if checkpoint ETA > 60 min).
 set -euo pipefail
 
-MODE="${1:?usage: run_extraction.sh [download|eta-check|extract]}"
+MODE="${1:?usage: run_extraction.sh [download|eta-check|extract] [tokens]}"
+TOKENS="${2:-1000000}"   # default 1M tokens (~2h20m); pass a smaller count if time is tighter
 
 MODEL_DIR=/model
 CKPT_REPO="wtdcode/GLM-5.3-Flash-AWQ-W4A16"
@@ -54,9 +58,10 @@ case "$MODE" in
     if [[ -f "$DATA/corpus.jsonl" ]]; then
       CORPUS_ARGS=(--corpus-jsonl "$DATA/corpus.jsonl")
     fi
+    echo "[extract] target: ${TOKENS} tokens (default 1M ~2h20m; --resume makes any stop-point usable)"
     PYTHONPATH="$TOOLS" python3 "$TOOLS/extract_hidden_states.py" \
       --model "$MODEL_DIR" --out "$OUT" --raw-dir "$RAW" \
-      --tokens 2000000 --tp 4 --max-len 4096 --shard-tokens 50000 \
+      --tokens "$TOKENS" --tp 4 --max-len 4096 --shard-tokens 50000 \
       --no-batch --resume "${CORPUS_ARGS[@]}" \
       2>&1 | tee "$LOGDIR/extract.log"
     echo "[extract] preflight gate check (should already have printed and been eyeballed live):"
@@ -66,14 +71,17 @@ case "$MODE" in
     grep -c "\[preflight\] ok" "$LOGDIR/extract.log" || true
     echo "[extract] hook check: must NOT be 'hooked 0 layers' or 'skipped-nonzero-rank' on every rank:"
     grep "hooked .* layers" "$LOGDIR/extract.log" || true
-    echo "[extract] five exit checks:"
-    python3 "$TOOLS/verify_manifest.py" "$OUT" 1800000
+    echo "[extract] five exit checks (min-tokens scaled to 90% of the ${TOKENS}-token target):"
+    min_tokens=$(python3 -c "print(int(${TOKENS}*0.9))")
+    python3 "$TOOLS/verify_manifest.py" "$OUT" "$min_tokens"
     ls "$OUT"/shard-*.npz 2>/dev/null | wc -l
     du -sh "$OUT"
     grep -c "id verification FAILED" "$LOGDIR/extract.log" || true
     grep -c "skip\]" "$LOGDIR/extract.log" || true
     echo "[extract] MUST confirm: aux_tap == hc_post-materialized+stream-mean, aux_layers == [5,14,24,33,42],"
-    echo "[extract]   tokens >= 1,800,000, ~40 shards ~82GB, zero FAILED, zero skips."
+    echo "[extract]   tokens >= ${min_tokens}, ~$((TOKENS/50000)) shards, zero FAILED, zero skips."
+    echo "[extract] If wall-clock is short, --resume means whatever shards exist so far are still usable —"
+    echo "[extract] stop the process and move to rsync-back/destroy rather than let it overrun the cap."
     ;;
   *) echo "usage: run_extraction.sh [eta-check|download|extract]"; exit 1 ;;
 esac

--- a/scripts/rental/run_extraction.sh
+++ b/scripts/rental/run_extraction.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Direct-exec translation of the drafter lane's slice-C PP4 extraction command
-# (seanphan/pixelml#108). Only run this if >=4 spare cards exist AND the time budget allows.
+# Only run this if >=4 spare cards exist AND the time budget allows.
 # Measured 120 tok/s on 4x170HX PP4. The bundle's own sizing (2M tokens, ~4h40m) does NOT
 # fit inside the 6h/$17 rental cap alongside training + AWQ download + boot, so this script
 # defaults to 1M tokens (~2h20m of compute) instead — size TOKENS down further at call time

--- a/scripts/rental/run_extraction.sh
+++ b/scripts/rental/run_extraction.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Direct-exec translation of the drafter lane's slice-C (2M token) PP4 extraction command
+# (seanphan/pixelml#108). Only run this if >=4 spare cards exist AND the time budget allows:
+# measured 120 tok/s on 4x170HX PP4 -> 2,000,000/120 =~ 4h40m plus ~15-20min weight load.
+# Requires the 178 GB AWQ checkpoint at /model — download it first with run_extraction.sh
+# download-only, check the ETA gate, THEN run extraction (abort extraction, not training,
+# if checkpoint ETA > 60 min).
+set -euo pipefail
+
+MODE="${1:?usage: run_extraction.sh [download|eta-check|extract]}"
+
+MODEL_DIR=/model
+CKPT_REPO="wtdcode/GLM-5.3-Flash-AWQ-W4A16"
+CKPT_BYTES_EXPECTED=190843146533   # 178 GiB
+DATA=/data
+TOOLS=/data/tools
+OUT=/out/sliceC
+RAW=/raw
+LOGDIR=/workspace/logs/extraction
+mkdir -p "$LOGDIR" "$OUT" "$RAW" "$MODEL_DIR"
+
+case "$MODE" in
+  eta-check)
+    echo "[extract] downloading first shard only to estimate rate..."
+    t0=$(date +%s)
+    hf download "$CKPT_REPO" --local-dir "$MODEL_DIR" --max-workers 16 \
+      --include "*.json" --include "*00001-of-*" 2>&1 | tee "$LOGDIR/eta-shard.log"
+    t1=$(date +%s)
+    shard_bytes=$(find "$MODEL_DIR" -type f -exec stat -c '%s' {} + | awk '{s+=$1} END {print s+0}')
+    elapsed=$((t1 - t0))
+    rate=$(python3 -c "print(${shard_bytes}/${elapsed}) if ${elapsed} else print(0)")
+    eta_min=$(python3 -c "print(round((${CKPT_BYTES_EXPECTED}-${shard_bytes})/max(${rate},1)/60,1))")
+    echo "[extract] shard: ${shard_bytes} bytes in ${elapsed}s => ${rate} B/s, full-download ETA ~${eta_min} min"
+    echo "${eta_min}" > "$LOGDIR/eta-minutes.txt"
+    if (( $(python3 -c "print(1 if ${eta_min} > 60 else 0)") )); then
+      echo "[extract] ABORT: ETA ${eta_min} min > 60 min cap. Do NOT proceed with slice C."
+      echo "[extract] Training continues regardless — this only gates the extraction lane."
+      exit 1
+    fi
+    echo "[extract] ETA within 60 min cap — proceed to 'download' then 'extract'"
+    ;;
+  download)
+    t0=$(date +%s)
+    hf download "$CKPT_REPO" --local-dir "$MODEL_DIR" --max-workers 16 | tee "$LOGDIR/download.log"
+    t1=$(date +%s)
+    actual=$(find "$MODEL_DIR" -type f -exec stat -c '%s' {} + | awk '{s+=$1} END {print s+0}')
+    echo "[extract] download took $((t1-t0))s, ${actual} bytes (expected ${CKPT_BYTES_EXPECTED})"
+    [[ "$actual" -ge "$((CKPT_BYTES_EXPECTED - 1048576))" ]] || { echo "[extract] ABORT: checkpoint incomplete"; exit 1; }
+    ;;
+  extract)
+    echo "[extract] CORPUS: point --corpus-jsonl at /data/corpus.jsonl if present, else this pulls"
+    echo "[extract] ultrachat_200k+tulu-3-sft-mixture which needs 'datasets' + network (not in image)."
+    CORPUS_ARGS=()
+    if [[ -f "$DATA/corpus.jsonl" ]]; then
+      CORPUS_ARGS=(--corpus-jsonl "$DATA/corpus.jsonl")
+    fi
+    PYTHONPATH="$TOOLS" python3 "$TOOLS/extract_hidden_states.py" \
+      --model "$MODEL_DIR" --out "$OUT" --raw-dir "$RAW" \
+      --tokens 2000000 --tp 4 --max-len 4096 --shard-tokens 50000 \
+      --no-batch --resume "${CORPUS_ARGS[@]}" \
+      2>&1 | tee "$LOGDIR/extract.log"
+    echo "[extract] preflight gate check (should already have printed and been eyeballed live):"
+    grep -c "drain/pack test OK" "$LOGDIR/extract.log" || true
+    grep -c "batched split/verify OK" "$LOGDIR/extract.log" || true
+    grep -c "segment resolution OK" "$LOGDIR/extract.log" || true
+    grep -c "\[preflight\] ok" "$LOGDIR/extract.log" || true
+    echo "[extract] hook check: must NOT be 'hooked 0 layers' or 'skipped-nonzero-rank' on every rank:"
+    grep "hooked .* layers" "$LOGDIR/extract.log" || true
+    echo "[extract] five exit checks:"
+    python3 "$TOOLS/verify_manifest.py" "$OUT" 1800000
+    ls "$OUT"/shard-*.npz 2>/dev/null | wc -l
+    du -sh "$OUT"
+    grep -c "id verification FAILED" "$LOGDIR/extract.log" || true
+    grep -c "skip\]" "$LOGDIR/extract.log" || true
+    echo "[extract] MUST confirm: aux_tap == hc_post-materialized+stream-mean, aux_layers == [5,14,24,33,42],"
+    echo "[extract]   tokens >= 1,800,000, ~40 shards ~82GB, zero FAILED, zero skips."
+    ;;
+  *) echo "usage: run_extraction.sh [eta-check|download|extract]"; exit 1 ;;
+esac

--- a/scripts/rental/run_queue.sh
+++ b/scripts/rental/run_queue.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Full measurement queue for the GLM-5.3-Flash rental. Idempotent/resumable:
+# each step writes a DONE marker under its receipts dir and is skipped if
+# already present (delete the marker to force a re-run of that step).
+#
+# NUM_GPUS controls what the box actually has (4, 6, or 8) and gates which
+# steps run: TP4/PP4-family steps need >=4; TP8 and the 2x-TP4-replica c=16
+# cell need >=8 and are skipped (not failed) below that.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH="$HERE/bench"
+RECEIPTS_ROOT="${RECEIPTS_ROOT:-/workspace/receipts}"
+NUM_GPUS="${NUM_GPUS:-8}"
+PY="${PY:-python3}"
+STEP_TIMEOUT_S="${STEP_TIMEOUT_S:-1800}"   # 30 min hang guard per bench call
+MM_FLAG_TESTED="${MM_FLAG_TESTED:-0}"      # set to 1 once step1 records the mm-profiling result
+
+log() { printf '[run_queue] %s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+done_marker() { echo "$1/DONE"; }
+skip_if_done() {
+  local dir="$1"
+  if [[ -f "$(done_marker "$dir")" ]]; then
+    log "skip (already done): $dir"
+    return 0
+  fi
+  return 1
+}
+mark_done() { mkdir -p "$1"; touch "$(done_marker "$1")"; }
+
+wait_ready() {
+  local port="$1" timeout="${2:-900}"
+  local waited=0
+  while ! curl -sf "http://127.0.0.1:${port}/v1/models" >/dev/null 2>&1; do
+    sleep 5; waited=$((waited + 5))
+    if [[ "$waited" -ge "$timeout" ]]; then
+      log "ERROR: server on port $port not ready after ${timeout}s"
+      return 1
+    fi
+  done
+  log "server on port $port ready after ${waited}s"
+}
+
+run_bench() {
+  # run_bench <out_dir> <base_url> <model> -- <script args...>
+  local out="$1" url="$2" model="$3"; shift 3; shift # drop the literal --
+  timeout "$STEP_TIMEOUT_S" "$PY" "$@" --base-url "$url" --model "$model" --out "$out"
+}
+
+# --- Step 0: preflight (superset of onstart's; safe to re-run) ---
+step_preflight() {
+  local d="$RECEIPTS_ROOT/00-preflight"
+  skip_if_done "$d" && return 0
+  mkdir -p "$d"
+  nvidia-smi --query-gpu=index,name,memory.total,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max,driver_version --format=csv | tee "$d/nvidia-smi-query.csv"
+  nvidia-smi topo -m | tee "$d/topo-m.txt"
+  nvidia-smi topo -p2p r 2>&1 | tee "$d/topo-p2p-r.txt"
+  df -h /workspace | tee "$d/disk.txt"
+  # simple local write bandwidth sample (not network; network bw is measured
+  # by onstart's checkpoint download time)
+  dd if=/dev/zero of="$d/.bwtest" bs=1M count=512 oflag=direct 2>&1 | tail -3 | tee "$d/disk-write-bw.txt"
+  rm -f "$d/.bwtest"
+  echo "$NUM_GPUS" > "$d/num_gpus.txt"
+  mark_done "$d"
+}
+
+# --- Step 1: TP4 recipe of record (cards 0-3), no mm-limit flag first ---
+step_tp4_record() {
+  local d="$RECEIPTS_ROOT/01-tp4-record"
+  skip_if_done "$d" && return 0
+  mkdir -p "$d"
+  local t0=$(date +%s)
+  NAME=glm53-tp4 PORT=18098 K=3 DEVICES=0,1,2,3 EXTRA_MM_FLAG='' bash "$HERE/launch_tp4.sh" 2>&1 | tee "$d/launch.log"
+  if wait_ready 18098 900; then
+    echo "mm_limit_flag_needed=false" > "$d/mm-flag-result.txt"
+  else
+    log "TP4 record: startup failed without mm-limit flag, retrying WITH it"
+    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    NAME=glm53-tp4 PORT=18098 K=3 DEVICES=0,1,2,3 \
+      EXTRA_MM_FLAG='--limit-mm-per-prompt {"image": 0, "video": 0}' \
+      bash "$HERE/launch_tp4.sh" 2>&1 | tee -a "$d/launch.log"
+    wait_ready 18098 900 || { log "ERROR: TP4 record failed to boot even with mm-limit flag"; docker logs glm53-tp4 2>&1 | tail -100 > "$d/boot-failure.log"; return 1; }
+    echo "mm_limit_flag_needed=true" > "$d/mm-flag-result.txt"
+  fi
+  local t1=$(date +%s)
+  echo "boot_time_s=$((t1 - t0))" > "$d/boot-time.txt"
+  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate prefill ttft decode_c1
+  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 3
+  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/context_sweep.py" --lengths 4096 16384 65536 --reps 3
+  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/lossless_check.py"
+  mark_done "$d"
+}
+
+# --- Step 2: TP4 variants (one factor each): P2P path, k=2, k=5 ---
+step_tp4_variants() {
+  local d="$RECEIPTS_ROOT/02-tp4-variants"
+  skip_if_done "$d" && return 0
+  mkdir -p "$d"
+  local p2p_available=0
+  if grep -qi 'OK' "$RECEIPTS_ROOT/00-preflight/topo-p2p-r.txt" 2>/dev/null; then p2p_available=1; fi
+
+  if [[ "$p2p_available" == "1" ]]; then
+    local sub="$d/p2p-custom-ar"
+    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    NAME=glm53-tp4 PORT=18098 K=3 DEVICES=0,1,2,3 NO_CUSTOM_AR=0 bash "$HERE/launch_tp4.sh"
+    if wait_ready 18098 900; then
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
+    else
+      log "P2P variant failed to boot"; mkdir -p "$sub"; docker logs glm53-tp4 2>&1 | tail -100 > "$sub/boot-failure.log"
+    fi
+  else
+    log "P2P not available on this box; skipping custom-all-reduce variant"
+  fi
+
+  for k in 2 5; do
+    local sub="$d/k$k"
+    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    NAME=glm53-tp4 PORT=18098 K=$k DEVICES=0,1,2,3 bash "$HERE/launch_tp4.sh"
+    if wait_ready 18098 900; then
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
+    else
+      log "k=$k variant failed to boot"; mkdir -p "$sub"; docker logs glm53-tp4 2>&1 | tail -100 > "$sub/boot-failure.log"
+    fi
+  done
+  mark_done "$d"
+}
+
+# --- Step 3: PP4 + MTP x5 verdict ---
+step_pp4() {
+  local d="$RECEIPTS_ROOT/03-pp4"
+  skip_if_done "$d" && return 0
+  mkdir -p "$d"
+  docker rm -f glm53-tp4 glm53-pp4 >/dev/null 2>&1 || true
+  DEVICES=0,1,2,3 bash "$HERE/launch_pp4.sh" 2>&1 | tee "$d/launch.log"
+  if wait_ready 18099 900; then
+    run_bench "$d" http://127.0.0.1:18099 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+    docker logs glm53-pp4 2>&1 | grep -Ei 'accept|draft' | tail -50 > "$d/acceptance-log-grep.txt" || true
+  else
+    log "PP4 failed to boot"
+    docker logs glm53-pp4 2>&1 | tail -150 > "$d/boot-failure.log"
+  fi
+  mark_done "$d"
+}
+
+# --- Step 4: TP8 + 2xTP4 replicas for c=16 (needs 8 cards) ---
+step_tp8() {
+  local d="$RECEIPTS_ROOT/04-tp8"
+  if [[ "$NUM_GPUS" -lt 8 ]]; then
+    log "NUM_GPUS=$NUM_GPUS < 8, skipping TP8 step"
+    mkdir -p "$d"; echo "skipped: NUM_GPUS=$NUM_GPUS < 8" > "$d/SKIPPED"
+    return 0
+  fi
+  skip_if_done "$d" && return 0
+  mkdir -p "$d"
+  docker rm -f glm53-pp4 glm53-tp4 glm53-tp8 >/dev/null 2>&1 || true
+  NAME=glm53-tp8 PORT=18098 K=3 DEVICES=0,1,2,3,4,5,6,7 bash "$HERE/launch_tp8.sh" 2>&1 | tee "$d/launch.log"
+  if wait_ready 18098 900; then
+    run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+    run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
+  else
+    log "TP8 failed to boot"; docker logs glm53-tp8 2>&1 | tail -150 > "$d/boot-failure.log"
+    mark_done "$d"; return 0
+  fi
+  docker rm -f glm53-tp8 >/dev/null 2>&1 || true
+
+  # 2x TP4 replicas (0-3, 4-7) for aggregate c=16
+  NAME=glm53-tp4a PORT=18098 K=3 DEVICES=0,1,2,3 bash "$HERE/launch_tp4.sh" 2>&1 | tee -a "$d/launch.log"
+  NAME=glm53-tp4b PORT=18100 K=3 DEVICES=4,5,6,7 bash "$HERE/launch_tp4.sh" 2>&1 | tee -a "$d/launch.log"
+  if wait_ready 18098 900 && wait_ready 18100 900; then
+    run_bench "$d/replica-a" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1 &
+    run_bench "$d/replica-b" http://127.0.0.1:18100 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1 &
+    wait
+  else
+    log "2x TP4 replica boot failed"
+  fi
+  docker rm -f glm53-tp4a glm53-tp4b >/dev/null 2>&1 || true
+  mark_done "$d"
+}
+
+# --- Step 5: collect ---
+step_collect() {
+  bash "$HERE/collect.sh"
+}
+
+main() {
+  log "starting queue, NUM_GPUS=$NUM_GPUS"
+  step_preflight
+  step_tp4_record
+  step_tp4_variants
+  step_pp4
+  step_tp8
+  step_collect
+  log "queue complete"
+}
+
+main "$@"

--- a/scripts/rental/run_queue.sh
+++ b/scripts/rental/run_queue.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Full measurement queue for the GLM-5.3-Flash rental. Idempotent/resumable:
-# each step writes a DONE marker under its receipts dir and is skipped if
-# already present (delete the marker to force a re-run of that step).
+# Full measurement queue for the GLM-5.3-Flash rental. Direct-exec (no
+# nested docker — the rental IS the club-170hx image container).
+# Idempotent/resumable: each step writes a DONE marker under its receipts
+# dir and is skipped if already present (delete the marker to force a
+# re-run of that step).
 #
 # NUM_GPUS controls what the box actually has (4, 6, or 8) and gates which
 # steps run: TP4/PP4-family steps need >=4; TP8 and the 2x-TP4-replica c=16
@@ -11,10 +13,12 @@ set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BENCH="$HERE/bench"
 RECEIPTS_ROOT="${RECEIPTS_ROOT:-/workspace/receipts}"
+LOGDIR="${LOGDIR:-/workspace/logs}"
+PIDDIR="${PIDDIR:-/workspace/pids}"
 NUM_GPUS="${NUM_GPUS:-8}"
 PY="${PY:-python3}"
 STEP_TIMEOUT_S="${STEP_TIMEOUT_S:-1800}"   # 30 min hang guard per bench call
-MM_FLAG_TESTED="${MM_FLAG_TESTED:-0}"      # set to 1 once step1 records the mm-profiling result
+mkdir -p "$LOGDIR" "$PIDDIR"
 
 log() { printf '[run_queue] %s %s\n' "$(date -u +%FT%TZ)" "$*"; }
 
@@ -28,6 +32,16 @@ skip_if_done() {
   return 1
 }
 mark_done() { mkdir -p "$1"; touch "$(done_marker "$1")"; }
+
+stop_server() {
+  local name="$1"
+  if [[ -f "$PIDDIR/$name.pid" ]]; then
+    kill "$(cat "$PIDDIR/$name.pid")" 2>/dev/null || true
+    sleep 3
+    kill -9 "$(cat "$PIDDIR/$name.pid")" 2>/dev/null || true
+    rm -f "$PIDDIR/$name.pid"
+  fi
+}
 
 wait_ready() {
   local port="$1" timeout="${2:-900}"
@@ -57,15 +71,13 @@ step_preflight() {
   nvidia-smi topo -m | tee "$d/topo-m.txt"
   nvidia-smi topo -p2p r 2>&1 | tee "$d/topo-p2p-r.txt"
   df -h /workspace | tee "$d/disk.txt"
-  # simple local write bandwidth sample (not network; network bw is measured
-  # by onstart's checkpoint download time)
   dd if=/dev/zero of="$d/.bwtest" bs=1M count=512 oflag=direct 2>&1 | tail -3 | tee "$d/disk-write-bw.txt"
   rm -f "$d/.bwtest"
   echo "$NUM_GPUS" > "$d/num_gpus.txt"
   mark_done "$d"
 }
 
-# --- Step 1: TP4 recipe of record (cards 0-3), no mm-limit flag first ---
+# --- Step 1: TP4 recipe of record (cards 0-3), mm-limit flag OFF first ---
 step_tp4_record() {
   local d="$RECEIPTS_ROOT/01-tp4-record"
   skip_if_done "$d" && return 0
@@ -76,16 +88,16 @@ step_tp4_record() {
     echo "mm_limit_flag_needed=false" > "$d/mm-flag-result.txt"
   else
     log "TP4 record: startup failed without mm-limit flag, retrying WITH it"
-    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    stop_server glm53-tp4
     NAME=glm53-tp4 PORT=18098 K=3 DEVICES=0,1,2,3 \
       EXTRA_MM_FLAG='--limit-mm-per-prompt {"image": 0, "video": 0}' \
       bash "$HERE/launch_tp4.sh" 2>&1 | tee -a "$d/launch.log"
-    wait_ready 18098 900 || { log "ERROR: TP4 record failed to boot even with mm-limit flag"; docker logs glm53-tp4 2>&1 | tail -100 > "$d/boot-failure.log"; return 1; }
+    wait_ready 18098 900 || { log "ERROR: TP4 record failed to boot even with mm-limit flag"; tail -200 "$LOGDIR/glm53-tp4.log" > "$d/boot-failure.log"; return 1; }
     echo "mm_limit_flag_needed=true" > "$d/mm-flag-result.txt"
   fi
   local t1=$(date +%s)
   echo "boot_time_s=$((t1 - t0))" > "$d/boot-time.txt"
-  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate prefill ttft decode_c1
+  run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" gate prefill ttft decode_c1
   run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 3
   run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/context_sweep.py" --lengths 4096 16384 65536 --reps 3
   run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/lossless_check.py"
@@ -102,13 +114,13 @@ step_tp4_variants() {
 
   if [[ "$p2p_available" == "1" ]]; then
     local sub="$d/p2p-custom-ar"
-    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    stop_server glm53-tp4
     NAME=glm53-tp4 PORT=18098 K=3 DEVICES=0,1,2,3 NO_CUSTOM_AR=0 bash "$HERE/launch_tp4.sh"
     if wait_ready 18098 900; then
-      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" gate decode_c1
       run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
     else
-      log "P2P variant failed to boot"; mkdir -p "$sub"; docker logs glm53-tp4 2>&1 | tail -100 > "$sub/boot-failure.log"
+      log "P2P variant failed to boot"; mkdir -p "$sub"; tail -200 "$LOGDIR/glm53-tp4.log" > "$sub/boot-failure.log"
     fi
   else
     log "P2P not available on this box; skipping custom-all-reduce variant"
@@ -116,13 +128,13 @@ step_tp4_variants() {
 
   for k in 2 5; do
     local sub="$d/k$k"
-    docker rm -f glm53-tp4 >/dev/null 2>&1 || true
+    stop_server glm53-tp4
     NAME=glm53-tp4 PORT=18098 K=$k DEVICES=0,1,2,3 bash "$HERE/launch_tp4.sh"
     if wait_ready 18098 900; then
-      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+      run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" gate decode_c1
       run_bench "$sub" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
     else
-      log "k=$k variant failed to boot"; mkdir -p "$sub"; docker logs glm53-tp4 2>&1 | tail -100 > "$sub/boot-failure.log"
+      log "k=$k variant failed to boot"; mkdir -p "$sub"; tail -200 "$LOGDIR/glm53-tp4.log" > "$sub/boot-failure.log"
     fi
   done
   mark_done "$d"
@@ -133,14 +145,15 @@ step_pp4() {
   local d="$RECEIPTS_ROOT/03-pp4"
   skip_if_done "$d" && return 0
   mkdir -p "$d"
-  docker rm -f glm53-tp4 glm53-pp4 >/dev/null 2>&1 || true
+  stop_server glm53-tp4
+  stop_server glm53-pp4
   DEVICES=0,1,2,3 bash "$HERE/launch_pp4.sh" 2>&1 | tee "$d/launch.log"
   if wait_ready 18099 900; then
-    run_bench "$d" http://127.0.0.1:18099 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
-    docker logs glm53-pp4 2>&1 | grep -Ei 'accept|draft' | tail -50 > "$d/acceptance-log-grep.txt" || true
+    run_bench "$d" http://127.0.0.1:18099 glm-5.3-flash -- "$BENCH/bench_glm53.py" gate decode_c1
+    grep -Ei 'accept|draft' "$LOGDIR/glm53-pp4.log" | tail -50 > "$d/acceptance-log-grep.txt" || true
   else
     log "PP4 failed to boot"
-    docker logs glm53-pp4 2>&1 | tail -150 > "$d/boot-failure.log"
+    tail -300 "$LOGDIR/glm53-pp4.log" > "$d/boot-failure.log"
   fi
   mark_done "$d"
 }
@@ -155,16 +168,17 @@ step_tp8() {
   fi
   skip_if_done "$d" && return 0
   mkdir -p "$d"
-  docker rm -f glm53-pp4 glm53-tp4 glm53-tp8 >/dev/null 2>&1 || true
+  stop_server glm53-pp4
+  stop_server glm53-tp4
   NAME=glm53-tp8 PORT=18098 K=3 DEVICES=0,1,2,3,4,5,6,7 bash "$HERE/launch_tp8.sh" 2>&1 | tee "$d/launch.log"
   if wait_ready 18098 900; then
-    run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" -- gate decode_c1
+    run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/bench_glm53.py" gate decode_c1
     run_bench "$d" http://127.0.0.1:18098 glm-5.3-flash -- "$BENCH/c8_stability.py" --concurrency 8 --rounds 1
   else
-    log "TP8 failed to boot"; docker logs glm53-tp8 2>&1 | tail -150 > "$d/boot-failure.log"
+    log "TP8 failed to boot"; tail -300 "$LOGDIR/glm53-tp8.log" > "$d/boot-failure.log"
     mark_done "$d"; return 0
   fi
-  docker rm -f glm53-tp8 >/dev/null 2>&1 || true
+  stop_server glm53-tp8
 
   # 2x TP4 replicas (0-3, 4-7) for aggregate c=16
   NAME=glm53-tp4a PORT=18098 K=3 DEVICES=0,1,2,3 bash "$HERE/launch_tp4.sh" 2>&1 | tee -a "$d/launch.log"
@@ -176,7 +190,8 @@ step_tp8() {
   else
     log "2x TP4 replica boot failed"
   fi
-  docker rm -f glm53-tp4a glm53-tp4b >/dev/null 2>&1 || true
+  stop_server glm53-tp4a
+  stop_server glm53-tp4b
   mark_done "$d"
 }
 

--- a/scripts/rental/run_training.sh
+++ b/scripts/rental/run_training.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Direct-exec translation of the drafter lane's "vast bundle" (seanphan/pixelml#108) six-run
+# sweep. The bundle's commands use `docker run --gpus device=N ... --entrypoint python3`
+# because it assumes a host with a docker daemon; this rental's --image IS the container
+# (no nested docker, no docker binary inside it — same finding as the inference lane), so
+# every run below is CUDA_VISIBLE_DEVICES + nohup + PID file instead.
+#
+# Must run AFTER transfer_specdec.sh has verified:
+#   tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9
+#   OK
+# Do not run this script if that gate did not pass verbatim.
+set -euo pipefail
+
+DATA=/data
+TOOLS=/data/tools
+OUT=/out
+LOGDIR=/workspace/logs/training
+PIDDIR=/workspace/pids/training
+IMAGE_PY=python3   # running inside the rented image directly; no docker run
+
+mkdir -p "$LOGDIR" "$PIDDIR" "$OUT"
+
+NUM_GPUS_TRAIN="${1:-6}"   # cards reserved for training (rest go to extraction if any)
+
+run() {   # run(name, gpu, block_size, lr, [init_from])
+  local name="$1" gpu="$2" bs="$3" lr="$4" init="${5:-}"
+  mkdir -p "$OUT/$name"
+  if [[ -f "$PIDDIR/$name.pid" ]] && kill -0 "$(cat "$PIDDIR/$name.pid")" 2>/dev/null; then
+    echo "[run] $name already running (pid $(cat "$PIDDIR/$name.pid")), skipping"
+    return 0
+  fi
+  local extra=()
+  [[ -n "$init" ]] && extra=(--init-from "$init")
+  echo "[run] starting $name on gpu $gpu: block_size=$bs lr=$lr init=${init:-none}"
+  CUDA_VISIBLE_DEVICES="$gpu" PYTHONPATH="$TOOLS" \
+    nohup $IMAGE_PY "$TOOLS/train_drafter.py" \
+      --data "$DATA/sliceB" --shared "$DATA/target-shared.safetensors" \
+      --out "$OUT/$name" --block-size "$bs" --lr "$lr" \
+      --steps 8000 --eval-every 500 --eval-blocks 400 "${extra[@]}" \
+      > "$LOGDIR/$name.log" 2>&1 &
+  echo $! > "$PIDDIR/$name.pid"
+}
+
+echo "[run_training] reference band check first (must land IN BAND ~36%):"
+PYTHONPATH="$TOOLS" $IMAGE_PY "$TOOLS/ref_eval2.py" \
+  --weights "$DATA/ref-drafter/model.safetensors" \
+  --shared "$DATA/target-shared.safetensors" --data "$DATA/sliceB" \
+  --blocks 800 --stride 16 --label reference-check \
+  | tee "$LOGDIR/reference-check.log"
+grep -q "IN BAND" "$LOGDIR/reference-check.log" || {
+  echo "[run_training] ABORT: reference band check did not land IN BAND (~36%). Data/transfer is wrong."
+  exit 1
+}
+
+# bs8 pair starts immediately on whichever 2 cards are free
+run bs8-lr15  0  8  1.5e-4
+run bs8-lr30  1  8  3e-4
+
+if [[ "$NUM_GPUS_TRAIN" -ge 6 ]]; then
+  echo "[run_training] waiting for bs8 checkpoints (best.pt) before starting bs13/bs17 (init-from)..."
+  for i in $(seq 1 60); do
+    [[ -f "$OUT/bs8-lr15/best.pt" && -f "$OUT/bs8-lr30/best.pt" ]] && break
+    sleep 30
+  done
+  if [[ -f "$OUT/bs8-lr15/best.pt" && -f "$OUT/bs8-lr30/best.pt" ]]; then
+    run bs13-lr15 2 13 1.5e-4 "$OUT/bs8-lr15/best.pt"
+    run bs13-lr30 3 13 3e-4   "$OUT/bs8-lr30/best.pt"
+    run bs17-lr15 4 17 1.5e-4 "$OUT/bs8-lr15/best.pt"
+    run bs17-lr30 5 17 3e-4   "$OUT/bs8-lr30/best.pt"
+  else
+    echo "[run_training] bs8 checkpoints not ready after 30 min; starting bs13/bs17 from scratch instead"
+    run bs13-lr15 2 13 1.5e-4
+    run bs13-lr30 3 13 3e-4
+    run bs17-lr15 4 17 1.5e-4
+    run bs17-lr30 5 17 3e-4
+  fi
+else
+  echo "[run_training] NUM_GPUS_TRAIN=$NUM_GPUS_TRAIN < 6: bs8 pair only, skipping bs13/bs17"
+fi
+
+echo "[run_training] all training runs launched. Logs: $LOGDIR/*.log"
+echo "[run_training] Expected first lines per run (abort that run if missing):"
+echo "  [data] 8 train shards, 757 samples, 1 held out"
+echo "  [shared] froze embed_tokens + lm_head from .../target-shared.safetensors"
+echo "  [model] block_size=N D=... trainable=1.1711B (81 tensors) == exported set"
+echo "  [frozen] embed_tokens + lm_head bit-identical after 20 steps"
+echo "Poll: tail -f $LOGDIR/<run>.log ; watch nvidia-smi"

--- a/scripts/rental/run_training.sh
+++ b/scripts/rental/run_training.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Direct-exec translation of the drafter lane's "vast bundle" (seanphan/pixelml#108) six-run
+# Direct-exec translation of the drafter lane's "vast bundle" six-run
 # sweep. The bundle's commands use `docker run --gpus device=N ... --entrypoint python3`
 # because it assumes a host with a docker daemon; this rental's --image IS the container
 # (no nested docker, no docker binary inside it — same finding as the inference lane), so

--- a/scripts/rental/run_training.sh
+++ b/scripts/rental/run_training.sh
@@ -52,28 +52,18 @@ grep -q "IN BAND" "$LOGDIR/reference-check.log" || {
   exit 1
 }
 
-# bs8 pair starts immediately on whichever 2 cards are free
-run bs8-lr15  0  8  1.5e-4
-run bs8-lr30  1  8  3e-4
+# Per the drafter lane (2026-09-05): against a 6h cap, run all six FROM SCRATCH in
+# parallel (one ~2.5h wave) rather than chaining bs13/bs17 off bs8 checkpoints via
+# --init-from (which would force two sequential ~2.4h waves and risk the cap). If
+# extraction finishes early and hours remain, re-run 13/17 with --init-from then.
+run bs8-lr15   0  8  1.5e-4
+run bs8-lr30   1  8  3e-4
 
 if [[ "$NUM_GPUS_TRAIN" -ge 6 ]]; then
-  echo "[run_training] waiting for bs8 checkpoints (best.pt) before starting bs13/bs17 (init-from)..."
-  for i in $(seq 1 60); do
-    [[ -f "$OUT/bs8-lr15/best.pt" && -f "$OUT/bs8-lr30/best.pt" ]] && break
-    sleep 30
-  done
-  if [[ -f "$OUT/bs8-lr15/best.pt" && -f "$OUT/bs8-lr30/best.pt" ]]; then
-    run bs13-lr15 2 13 1.5e-4 "$OUT/bs8-lr15/best.pt"
-    run bs13-lr30 3 13 3e-4   "$OUT/bs8-lr30/best.pt"
-    run bs17-lr15 4 17 1.5e-4 "$OUT/bs8-lr15/best.pt"
-    run bs17-lr30 5 17 3e-4   "$OUT/bs8-lr30/best.pt"
-  else
-    echo "[run_training] bs8 checkpoints not ready after 30 min; starting bs13/bs17 from scratch instead"
-    run bs13-lr15 2 13 1.5e-4
-    run bs13-lr30 3 13 3e-4
-    run bs17-lr15 4 17 1.5e-4
-    run bs17-lr30 5 17 3e-4
-  fi
+  run bs13-lr15  2 13 1.5e-4
+  run bs13-lr30  3 13 3e-4
+  run bs17-lr15  4 17 1.5e-4
+  run bs17-lr30  5 17 3e-4
 else
   echo "[run_training] NUM_GPUS_TRAIN=$NUM_GPUS_TRAIN < 6: bs8 pair only, skipping bs13/bs17"
 fi

--- a/scripts/rental/transfer_specdec.sh
+++ b/scripts/rental/transfer_specdec.sh
@@ -47,7 +47,7 @@ rm -f "$LOCAL_STAGE/1g.bin"
 echo "[transfer] 3/5: stage small files locally (tools tarball, target-shared, checksums)"
 t0=$(date +%s)
 rsync -az -e "ssh -o StrictHostKeyChecking=no" \
-  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/specdec-tools-a774a822.tar.gz" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/specdec-tools-eb1434a8.tar.gz" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/target-shared.safetensors" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/SHARED.sha256" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/REFDRAFTER.sha256" \
@@ -75,10 +75,10 @@ echo "[transfer] pushed to rental in $((t1 - t0))s"
 echo "[transfer] unpack + verify on rental"
 $DEST_SSH "$SPECDEC_DEST_HOST" '
   set -e
-  cd /data && tar xzf specdec-tools-a774a822.tar.gz
+  cd /data && tar xzf specdec-tools-eb1434a8.tar.gz
   test -d specdec-wt/tools/specdec && mkdir -p tools && cp -r specdec-wt/tools/specdec tools/ || true
   find /data -maxdepth 2 -iname "*.py" -path "*specdec*" | head -3
-  sha256sum specdec-tools-a774a822.tar.gz
+  sha256sum specdec-tools-eb1434a8.tar.gz
   cd /data/sliceB && sha256sum -c SHA256SUMS --quiet && echo SLICEB_OK
   python3 /data/tools/verify_manifest.py /data/sliceB 400000
 '

--- a/scripts/rental/transfer_specdec.sh
+++ b/scripts/rental/transfer_specdec.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Runs LOCALLY (on the orchestrating machine), not on the rental. Relays data from the
+# internal source host to the rented Vast instance in two hops (source has no route to
+# the rental; the orchestrating machine has ssh access to both).
+#
+# Required env (no defaults — do not hardcode private hosts into this file):
+#   SPECDEC_SOURCE      ssh target for the internal source host, e.g. user@100.x.x.x
+#   SPECDEC_DEST_HOST   ssh host/user for the rented instance, e.g. root@<vast-ip>
+#   SPECDEC_DEST_PORT   ssh port for the rented instance, e.g. 41234
+#
+# Usage:
+#   SPECDEC_SOURCE=user@<internal-host> \
+#   SPECDEC_DEST_HOST=root@<vast-ip> SPECDEC_DEST_PORT=<port> \
+#     scripts/rental/transfer_specdec.sh
+set -euo pipefail
+
+: "${SPECDEC_SOURCE:?set SPECDEC_SOURCE=user@host (internal source, not committed here)}"
+: "${SPECDEC_DEST_HOST:?set SPECDEC_DEST_HOST=root@<vast-ip>}"
+: "${SPECDEC_DEST_PORT:?set SPECDEC_DEST_PORT=<vast-ssh-port>}"
+
+SRC_DATA_DIR=/library/models/specdec-data
+DEST_SSH="ssh -o StrictHostKeyChecking=no -p ${SPECDEC_DEST_PORT}"
+LOCAL_STAGE=$(mktemp -d)
+trap 'rm -rf "$LOCAL_STAGE"' EXIT
+
+rate_mb_s() { # rate_mb_s <bytes> <seconds>
+  python3 -c "b=$1; s=$2 or 1; print(round(b/1e6/s,1))"
+}
+
+echo "[transfer] 1/5: 1 GB rate test, source -> local stage"
+t0=$(date +%s)
+ssh "$SPECDEC_SOURCE" "head -c 1073741824 /dev/urandom > /tmp/specdec-1g.bin"
+scp -q "$SPECDEC_SOURCE:/tmp/specdec-1g.bin" "$LOCAL_STAGE/1g.bin"
+t1=$(date +%s)
+echo "[transfer] source->local: $((t1 - t0))s, $(rate_mb_s 1073741824 $((t1 - t0))) MB/s"
+ssh "$SPECDEC_SOURCE" "rm -f /tmp/specdec-1g.bin"
+
+echo "[transfer] 2/5: 1 GB rate test, local stage -> rental"
+t0=$(date +%s)
+scp -q -P "$SPECDEC_DEST_PORT" -o StrictHostKeyChecking=no \
+  "$LOCAL_STAGE/1g.bin" "${SPECDEC_DEST_HOST}:/tmp/specdec-1g.bin"
+t1=$(date +%s)
+echo "[transfer] local->rental: $((t1 - t0))s, $(rate_mb_s 1073741824 $((t1 - t0))) MB/s"
+ssh -p "$SPECDEC_DEST_PORT" -o StrictHostKeyChecking=no "$SPECDEC_DEST_HOST" "rm -f /tmp/specdec-1g.bin; mkdir -p /data"
+rm -f "$LOCAL_STAGE/1g.bin"
+
+echo "[transfer] 3/5: stage small files locally (tools tarball, target-shared, checksums)"
+t0=$(date +%s)
+rsync -az -e "ssh -o StrictHostKeyChecking=no" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/specdec-tools-a774a822.tar.gz" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/target-shared.safetensors" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/SHARED.sha256" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/REFDRAFTER.sha256" \
+  "$LOCAL_STAGE/"
+mkdir -p "$LOCAL_STAGE/ref-drafter"
+rsync -az -e "ssh -o StrictHostKeyChecking=no" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/ref-drafter/" "$LOCAL_STAGE/ref-drafter/" 2>&1 || \
+  echo "[transfer] WARN: ref-drafter/ not found at that path on source — locate it before training"
+t1=$(date +%s)
+echo "[transfer] small files staged in $((t1 - t0))s"
+
+echo "[transfer] 4/5: sliceB (14 GB), source -> local stage"
+t0=$(date +%s)
+rsync -az --info=progress2 -e "ssh -o StrictHostKeyChecking=no" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/sliceB" "$LOCAL_STAGE/"
+t1=$(date +%s)
+echo "[transfer] sliceB staged in $((t1 - t0))s, $(rate_mb_s 15032385536 $((t1 - t0))) MB/s"
+
+echo "[transfer] 5/5: push staged data to rental /data"
+t0=$(date +%s)
+rsync -az --info=progress2 -e "$DEST_SSH" "$LOCAL_STAGE/" "${SPECDEC_DEST_HOST}:/data/"
+t1=$(date +%s)
+echo "[transfer] pushed to rental in $((t1 - t0))s"
+
+echo "[transfer] unpack + verify on rental"
+$DEST_SSH "$SPECDEC_DEST_HOST" '
+  set -e
+  cd /data && tar xzf specdec-tools-a774a822.tar.gz
+  test -d specdec-wt/tools/specdec && mkdir -p tools && cp -r specdec-wt/tools/specdec tools/ || true
+  find /data -maxdepth 2 -iname "*.py" -path "*specdec*" | head -3
+  sha256sum specdec-tools-a774a822.tar.gz
+  cd /data/sliceB && sha256sum -c SHA256SUMS --quiet && echo SLICEB_OK
+  python3 /data/tools/verify_manifest.py /data/sliceB 400000
+'
+echo "[transfer] gate: the line above MUST read"
+echo "[transfer]   tap hc_post-materialized+stream-mean tokens 455367 shards 9 files 9"
+echo "[transfer]   OK"
+echo "[transfer] If it differs, STOP — do not start training."

--- a/scripts/rental/transfer_specdec.sh
+++ b/scripts/rental/transfer_specdec.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 : "${SPECDEC_DEST_HOST:?set SPECDEC_DEST_HOST=root@<vast-ip>}"
 : "${SPECDEC_DEST_PORT:?set SPECDEC_DEST_PORT=<vast-ssh-port>}"
 
-SRC_DATA_DIR=/library/models/specdec-data
+SRC_DATA_DIR="${SRC_DATA_DIR:?set SRC_DATA_DIR to the model-library path holding the drafter training data}"
 DEST_SSH="ssh -o StrictHostKeyChecking=no -p ${SPECDEC_DEST_PORT}"
 LOCAL_STAGE=$(mktemp -d)
 trap 'rm -rf "$LOCAL_STAGE"' EXIT

--- a/scripts/rental/transfer_specdec.sh
+++ b/scripts/rental/transfer_specdec.sh
@@ -47,7 +47,7 @@ rm -f "$LOCAL_STAGE/1g.bin"
 echo "[transfer] 3/5: stage small files locally (tools tarball, target-shared, checksums)"
 t0=$(date +%s)
 rsync -az -e "ssh -o StrictHostKeyChecking=no" \
-  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/specdec-tools-eb1434a8.tar.gz" \
+  "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/specdec-tools-e03679f1.tar.gz" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/target-shared.safetensors" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/SHARED.sha256" \
   "${SPECDEC_SOURCE}:${SRC_DATA_DIR}/REFDRAFTER.sha256" \
@@ -75,10 +75,10 @@ echo "[transfer] pushed to rental in $((t1 - t0))s"
 echo "[transfer] unpack + verify on rental"
 $DEST_SSH "$SPECDEC_DEST_HOST" '
   set -e
-  cd /data && tar xzf specdec-tools-eb1434a8.tar.gz
+  cd /data && tar xzf specdec-tools-e03679f1.tar.gz
   test -d specdec-wt/tools/specdec && mkdir -p tools && cp -r specdec-wt/tools/specdec tools/ || true
   find /data -maxdepth 2 -iname "*.py" -path "*specdec*" | head -3
-  sha256sum specdec-tools-eb1434a8.tar.gz
+  sha256sum specdec-tools-e03679f1.tar.gz
   cd /data/sliceB && sha256sum -c SHA256SUMS --quiet && echo SLICEB_OK
   python3 /data/tools/verify_manifest.py /data/sliceB 400000
 '


### PR DESCRIPTION
## Summary
- Adds `scripts/rental/` for the Vast.ai 8x CMP 170HX GLM-5.3-Flash rental: `onstart.sh` (checkpoint download/verify + power cap + preflight receipts, no docker pull — the instance runs the image directly), `run_queue.sh` (NUM_GPUS-gated measurement queue: preflight, TP4 recipe of record, TP4 variants, PP4 verdict, TP8 + 2x-TP4 c=16 replicas), `launch_tp4.sh`/`launch_pp4.sh`/`launch_tp8.sh` (direct-exec `vllm serve` via nohup+PID, no nested docker — confirmed the image has no docker/dockerd binary), `bench/` (base-url/model-parameterized `bench_glm53.py` + `c8_stability.py`, plus new `lossless_check.py` 20-prompt greedy-determinism check and `context_sweep.py` 4k/16k/64k prefill sweep), `collect.sh`, and `RUNBOOK.md` with the exact pinned rental command.
- Adds `scripts/rental/find_offer.sh` to re-check the Vast.ai CMP 170HX market, sorted by PCIe bandwidth. **Note:** `verified=any` is required — vastai hides unverified hosts by default, and the only 8x CMP 170HX hosts currently on the market are unverified. Without the flag, 8x listings silently vanish.
- Fixes a reproducibility gap in `notebooks/2026-09-03-glm-5.3-flash-4card-tp4-vllm.ipynb`: the Reproduce section's "Bench" cell described the bench methodology in prose but gave no runnable command. Added the verbatim `bench_glm53.py` invocation and a pointer to the rental RUNBOOK for the fuller rental bench set.

## Status
Draft — Phase 1 (prepare) complete, no GPU rented, no money spent. `bash -n` clean on all scripts, `ast.parse` clean on all bench scripts, `--help` smoke-tested, `find_offer.sh` live-tested against the real market (offer `49884606`: 8x, PCIe Gen2 x16, confirmed available), `hf download` flags verified against the image's installed CLI. Rental itself is gated on go-ahead — see RUNBOOK section 2 for the exact pinned command.

## Test plan
- [x] `bash -n` on all `.sh` files
- [x] `python3 -c "import ast; ast.parse(...)"` on all bench `.py` files
- [x] `--help` smoke test on all bench scripts
- [x] `find_offer.sh 8` run against the live Vast.ai market (verified=any required to see 8x)
- [x] `hf download --help` flags verified against the image's installed CLI (1.30.0)
- [x] Confirmed the image has no docker/dockerd binary -> rewrote launch scripts to direct-exec `vllm serve` (nohup+PID), not `docker run`
- [x] Notebook JSON validity preserved after the Bench-cell fix (minimal single-cell diff)
- [ ] Full `run_queue.sh` execution on a rented 8x box (pending go-ahead on renting)