### PR TITLE
docs: CMP 170HX topology, PP vs TP, and operator lessons (2026-09-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The CMP 170HX shares useful traits with A100-class hardware, including SM80 comp
 | Validate a new or used card | [QC and acceptance testing](docs/QC.md) |
 | Control heat and noise | [Cooling and power](docs/COOLING-AND-POWER.md) |
 | Plan a multi-card node | [Cluster design](docs/CLUSTER.md) |
+| Understand the PCIe link and choose PP vs TP | [Topology and parallelism](docs/TOPOLOGY-AND-PARALLELISM.md) |
 | Diagnose failures | [Troubleshooting](docs/TROUBLESHOOTING.md) |
 | Compare measured results | [Benchmarks](docs/BENCHMARKS.md) |
 | Avoid past operator mistakes | [Operator lessons](docs/OPERATOR-LESSONS.md) |

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -62,6 +62,10 @@ suspicion; the 2026-09-02 health gate traced it to lane sharing instead).
 For comparison, consumer GeForce cards on the same host show x1 width at
 2.5GT/s at idle; that is normal ASPM power-saving behavior, not a fault.
 
+For the bandwidth this link width implies, the PP-vs-TP topology choice it
+forces, and the no-P2P/host-memory finding, see
+[Topology and parallelism](TOPOLOGY-AND-PARALLELISM.md).
+
 ## Known-good measured configuration
 
 **Measured inventory:** four cards enumerated in one Ubuntu guest on 2026-08-30 and exposed 65,536 MiB each, for 256 GiB aggregate. Four-card workload performance remains untested.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -66,6 +66,12 @@ dequantize fine on SM80; FP8/FP4 **tensor-core compute** does not exist here.
 
 ## c. Topology: pipeline parallel vs tensor parallel
 
+For the card/link-level mechanism behind this section (why the PCIe link is
+Gen1, why x8 slots are not a fault, why PP has a fundamentally different
+communication shape than TP, and the GLM-5.3-Flash PP4 vs TP4 numbers), see
+[TOPOLOGY-AND-PARALLELISM.md](TOPOLOGY-AND-PARALLELISM.md). This section keeps
+the per-checkpoint findings for DeepSeek-V4-Flash-0731.
+
 The tested CMP 170HX fabric has **no NVLink and no P2P over PCIe Gen2 x4**
 (about 1.0 GB/s measured bus bandwidth between cards). This one fact decides
 the topology choice.

--- a/docs/OPERATOR-LESSONS.md
+++ b/docs/OPERATOR-LESSONS.md
@@ -86,8 +86,88 @@ Ranked by rough wall-clock cost:
 14. Before any A/B change: write down the single variable being changed, the numeric decision gate, and the rollback plan, and commit that pre-run checkpoint before starting.
 15. Replace any package-presence check with an architecture-aware capability check before trusting a fast-path branch on hardware that lacks native support for it.
 
+## 6. A card that drops under multimodal-encoder profiling: diagnosing slot power vs. riser vs. card
+
+Mined from a multi-day debugging thread on a four-card node, 2026-09-04.
+
+**vLLM's multimodal-encoder profiling step is the largest power/bus transient
+of a boot.** The stage that profiles the vision/video encoder against the
+maximum feature size draws a sharper, larger transient than steady-state
+decode or even prefill. Treat it as a deliberate stress test for a marginal
+card position, not an incidental crash site: if a card is going to fall off
+the bus under load, this step is where it will happen first.
+
+**A card that drops (`rev ff`, D3cold-style loss) under that transient, with
+a clean link and no correctable PCIe errors right up to the drop, points at
+slot power delivery — not the riser and not the card.** The discriminating
+signature: a healthy link status (no `CorrErr`/`BadTLP`/timeout counters
+climbing) immediately before the device vanishes from the bus is not
+consistent with a signal-integrity problem (which usually shows correctable
+errors building up first); it is consistent with a power rail sagging under
+a sudden current draw and the device browning out.
+
+**Riser swap and card swap are the two discriminating tests, run in that
+order.** Swap the riser at the affected position for a known-good one and
+reproduce the load: if the drop recurs on the very next boot, the riser is
+cleared. Then swap the card at that position with a card from a stable
+position: if the failure stays with the position rather than following the
+card, the card is cleared too. What is left — the slot's power delivery —
+is the remaining hypothesis, and it is the one to test next (power-limit the
+card and retry, or move its power feed to a different rail).
+
+**`--limit-mm-per-prompt '{"image":0,"video":0}'` is the text-only
+workaround.** Passing zero for both image and video limits skips the
+multimodal-encoder profiling stage entirely at boot. On the affected node
+this let the server boot clean and serve text-only traffic stably across
+repeated concurrency rounds with no further drops, while leaving the actual
+vision-serving path unfixed and unmeasured. Use this flag to keep a lane
+moving on text while the hardware root cause is chased separately — it is a
+workaround, not a fix, and does not clear the card/slot for other
+peak-load workloads.
+
+**Recovery ladder for a card that has fallen off the bus, cheapest first,
+never skip a step:**
+
+1. Guest-side kernel module reload (unload then reload the GPU driver
+   modules) — recovers a device that is still enumerated on the guest's PCI
+   bus but wedged at the driver level.
+2. A full VM reboot — recovers a guest-level wedge that a module reload
+   alone does not clear.
+3. A cold power cycle of the host — required when the device has actually
+   left the host-side PCI bus (not just the guest's view of it), which a
+   guest reboot cannot fix.
+
+**Never run a host-side device "remove" on the passthrough device as a
+recovery step.** It turns a recoverable wedge into a card that vanishes
+from the host bus entirely and forces a full cold power cycle to bring
+back — a strictly worse outcome than doing nothing and going straight to
+the VM reboot or cold cycle above.
+
+**A VM reboot can itself land in a stuck power state** — the guest reports
+being unable to move the device from a low-power state back to an active
+one. Treat that specific failure as equivalent to step 3: it needs a cold
+power cycle, not a second reboot attempt.
+
+**Slot power-delivery headroom matters most when several cards share one
+bifurcated slot or riser position.** Powered risers, or an onboard
+low-voltage power-input header on the riser/backplane feeding a slot that
+several cards share, are the durable fix once slot power delivery is
+confirmed (not merely suspected) as the root cause — an MCIO-style
+bifurcation kit with its own powered device board is the reference
+approach for a slot carrying more than one card's worth of peak transient
+current.
+
+**Power cap re-apply after any module reload.** A per-card power limit set
+with the driver's runtime power-limit tool does not survive a guest reboot
+or a kernel module reload. Re-apply the power cap and verify it against
+every card's reported power limit after either event, before taking any
+measurement — a card silently back at its default (higher) power limit
+after a "recovery" is itself a new risk factor for the exact transient this
+section describes.
+
 ## See also
 
 - [LESSONS.md](LESSONS.md) — kernel, runtime, topology, memory/storage, power/thermal, and hardware failure-mode lessons.
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — symptom-to-cause diagnosis at the hardware/driver layer.
 - [MODEL-STATUS.md](MODEL-STATUS.md) — every model attempted on CMP 170HX, one table.
+- [TOPOLOGY-AND-PARALLELISM.md](TOPOLOGY-AND-PARALLELISM.md) — PCIe link facts and PP-vs-TP topology choice for this card.

--- a/docs/TOPOLOGY-AND-PARALLELISM.md
+++ b/docs/TOPOLOGY-AND-PARALLELISM.md
@@ -1,0 +1,248 @@
+# Topology and parallelism on CMP 170HX: what the link really is, and why PP beats TP here
+
+This page is the card/link-level companion to [LESSONS.md §c](LESSONS.md#c-topology-pipeline-parallel-vs-tensor-parallel)
+(per-checkpoint topology findings) and [CLUSTER.md](CLUSTER.md) (multi-node
+design). Read this page first if you are choosing tensor parallel (TP) vs
+pipeline parallel (PP) on this card; read the other two for a specific
+checkpoint's numbers or for scaling past one node.
+
+Every claim below is labeled **measured**, **inferred**, **community-reported**,
+or **untested**, per [AGENTS.md](../AGENTS.md). "Measured" means measured on
+this club's four-card CMP 170HX test node unless a different source is named.
+
+## 1. What the link really is
+
+**The CMP 170HX's PCIe link is Gen1 x16 by design (measured).** Host-side
+`lspci -vv` on the hypervisor shows every tested card advertising
+`LnkCap: Speed 2.5GT/s, Width x16` — that is PCIe Gen1, and it is the card's
+own capability register, not a hypervisor or passthrough artifact. An x16
+riser cannot raise it: the ceiling is set in the card's vBIOS, not the
+cabling. See [HARDWARE.md — PCIe link status](HARDWARE.md#pcie-link-status)
+for the original measurement.
+
+**A card that trains at x8 on a bifurcated slot is at that slot's ceiling,
+not a fault (measured).** On the tested board (dual-socket, seven
+physically populated slots), some root ports bifurcate x16 into x8/x8
+between two neighboring slots. A card in one of those slots training at x8
+instead of the board's advertised x16 is normal bifurcated-slot behavior,
+not riser damage or a passthrough bug — confirmed by swapping the riser (a
+new x16 riser did not change the width) and by swapping the card into the
+position (the x8 ceiling stayed with the slot, not the card). `dmidecode`
+slot tables on this board class are unreliable (list fewer slots than
+exist, mark used slots "Unknown"); do not use them to identify a physical
+slot.
+
+**No P2P under VFIO passthrough; NCCL/collective traffic goes through host
+memory (measured).** The tested fabric has no NVLink and no working P2P
+over PCIe in this passthrough configuration. Every inter-card tensor
+transfer — an all-reduce operand, a pipeline hand-off — round-trips through
+host RAM rather than card-to-card DMA.
+
+**Bandwidth by link width, PCIe Gen1, one direction (inferred from the
+PCIe Gen1 spec: ~250 MB/s per lane per direction).** Not independently
+re-measured on this box; treat as the theoretical ceiling, not an achieved
+number.
+
+| Link | Per-direction bandwidth (Gen1, theoretical) |
+|---|---:|
+| x1 | ~250 MB/s |
+| x8 | ~2 GB/s |
+| x16 | ~4 GB/s |
+
+A card in an x8 bifurcated slot with no P2P is moving inter-card tensors
+through host memory over a link that theoretically tops out around 2 GB/s
+per direction — call this the operating envelope for any collective or
+hand-off strategy on this box, not a number to plan multi-card throughput
+past.
+
+## 2. Why pipeline parallel beats tensor parallel on this card
+
+**Tensor parallel does one all-reduce per layer per token (measured, this
+lane; consistent with the independent per-checkpoint finding in
+[LESSONS.md §c](LESSONS.md#c-topology-pipeline-parallel-vs-tensor-parallel)).**
+Every layer boundary is a synchronization point: all four ranks block until
+the slowest one's reduce lands. On a Gen1 fabric with no P2P, that is
+latency-bound, not bandwidth-bound — the round trip through host memory
+costs the same whether the tensor is large or small. Measured on
+GLM-5.3-Flash AWQ W4A16, TP4, MTP k=3 (`ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903`,
+fork `PixelML/sm80vllm@f6fbf3b854`): **60.4 tok/s c=1 decode (median of 5,
+peak 77.9)**, **~38 tok/s aggregate decode at c=8** (three rounds: 36.3 /
+38.8 / 38.1 tok/s, 8/8 requests OK each round; text-only, mm-encoder
+profiling skipped — see §3).
+
+**Pipeline parallel does one hidden-state hand-off per stage boundary
+instead (measured on this card's PP4 boot; see §3).** With N pipeline
+stages there are N-1 hand-offs per token per forward pass, each moving one
+hidden-state tensor once, versus TP's per-layer all-reduce. The per-step
+cost on a PP fabric therefore looks like a small fixed overhead per hop
+plus a cost that scales with how much is actually verified per step — which
+is exactly the lever speculative decoding pulls.
+
+**Community-reported cost model, 8-stage PP, from
+[promisezackr/glm53-flash-170hx-pp8](https://github.com/promisezackr/glm53-flash-170hx-pp8)
+(commit `90ec72e`, Apache-2.0, derivative of vLLM):** measured with
+per-stage CUDA events on their 8-card PCIe Gen2 x4 box, step time
+`≈ 32 ms fixed + 2.1 ms × verified tokens per step`. The fixed part is
+attributed to the serial 8-stage pipeline (per-stage attention/expert
+compute plus hop and host-side prep/sampling latency); the variable part
+to active-expert weight bandwidth, which scales with tokens × top-k. This
+is their number on their hardware (Gen2 x4, 8 cards, NVFP4 + DFlash2), not
+reproduced on this club's Gen1 x8/x16 four-card box — carried here as the
+shape of the cost model, not as our own measurement. Under that model,
+accepted draft length per step is the throughput lever: a wider accepted
+block amortizes the fixed 32 ms over more tokens.
+
+**Community-reported result at that cost model's target operating point:**
+GLM-5.3-Flash NVFP4, PP8, DFlash2 k=7, 8x CMP 170HX at PCIe Gen2 x4 (a
+faster link than this club's Gen1 x8 boxes): single-stream decode 123
+tok/s (code), 37 tok/s (prose) — the source explicitly reports acceptance
+and hence throughput varies by workload, so both numbers are named with
+their content type, not averaged. Steady-state aggregate at 16 concurrent
+streams: 276 tok/s. Source:
+[promisezackr/glm53-flash-170hx-pp8](https://github.com/promisezackr/glm53-flash-170hx-pp8),
+commit `90ec72e9525e90be701e742c70a20c4154418307`, README benchmark tables.
+**Attribution:** Apache-2.0, derivative of vLLM; their SM8x port itself
+credits [344303947/vllm170hx](https://github.com/344303947/vllm170hx) for the
+base SM8x patch set and [bayley/vllm-170hx-glm5](https://github.com/bayley)
+for PP-on-170HX validation. We have not run their patch set; the numbers
+above are cited for comparison, not reused as our own measurement.
+
+**Our PP4 today is not faster than TP4 — state this plainly.** GLM-5.3-Flash
+AWQ W4A16, PP4 (`VLLM_PP_LAYER_PARTITION=14,12,12,7`), `--enforce-eager`,
+`--gpu-memory-utilization 0.92`, on the same four-card box and checkpoint
+as the TP4 numbers above (measured 2026-09-04):
+
+| Metric | PP4 | TP4 (numbers of record) |
+|---|---:|---:|
+| c=1 decode, median tok/s | 3.35 (MTP k=5) | 60.4 (MTP k=3) |
+| c=1 decode, spec off | 6.1 (median of 3) | not separately measured |
+| c=8 aggregate tok/s (3 rounds) | 17.1 / 18.1 / 18.7 | 36.3 / 38.8 / 38.1 |
+| Uncached prefill, ~2,900-token prompt, tok/s | 1,053 | 818 |
+
+PP4 wins on prefill (a single large batch spreads across stages, and
+prefill has no per-step decode bubble to pay) but loses badly on decode.
+Two separable causes, isolated with a same-config MTP-on/MTP-off A/B on
+this box (measured 2026-09-04): (a) MTP under PP on this fork's current
+state produces clean text but only ~1.8x the spec-off throughput (6.1 vs
+3.35 tok/s) — most of the collapse is not MTP; (b) the base PP4 pipeline
+itself, with `--enforce-eager` (no CUDA graphs to hide the bubble), is
+structurally slow on this partition regardless of speculative decoding.
+**Community-reported fix for the MTP-under-PP part:** upstream vLLM's PP
+path skips loading the MTP draft model's `embed_tokens` / `shared_head.head`
+weights from the checkpoint under pipeline parallelism, leaving them
+randomly initialized and driving acceptance toward zero — documented as
+patch category 3 ("MTP under PP") in
+[promisezackr/glm53-flash-170hx-pp8](https://github.com/promisezackr/glm53-flash-170hx-pp8#what-the-patches-do).
+Porting that fix to this club's `glm53-sm80` fork is in progress and
+unmeasured here; **PP4 on the current unpatched fork is not a viable
+alternative to TP4 for decode throughput**, full stop, until that port
+lands and is re-measured.
+
+**PP is also expected to transfer to A100 boxes without NVLink (inferred,
+not tested on A100).** The same argument — one hand-off per stage boundary
+beats one all-reduce per layer when there is no fast interconnect — does
+not depend on anything specific to the CMP 170HX; it applies to any
+no-NVLink multi-GPU box. Untested on this club's own hardware pool since
+we have no A100s; carried here as a design hypothesis for anyone planning
+a similar box.
+
+## 3. PP boot facts
+
+All measured on the four-card CMP 170HX box, GLM-5.3-Flash AWQ W4A16,
+2026-09-04, image `ghcr.io/pixelml/club-170hx:vllm-glm53-sm80-20260903`.
+
+- **`VLLM_PP_LAYER_PARTITION` is honoured exactly.** Setting
+  `VLLM_PP_LAYER_PARTITION=14,12,12,7` on a 45-layer model produced layer
+  ranges 0–14 / 14–26 / 26–38 / 38–45 across the four pipeline stages — a
+  direct check of the env var against the resulting per-stage layer count.
+- **`--gpu-memory-utilization 0.80` leaves negative KV headroom on this
+  partition; `0.92` serves.** At 0.80, each card spends its whole memory
+  budget (0.80 × 64 GiB) on weights (44.5–45.5 GiB/card for this
+  partition) plus activation/CUDA-graph overhead, leaving no room for KV
+  cache — the engine fails at KV-cache allocation with a negative
+  "Available KV cache memory" value, independent of `--max-model-len`
+  (tried at both 524,288 and 262,144, both failed the same way). Raising
+  `--gpu-memory-utilization` to 0.92 fixed it: KV cache allocated
+  (1,248,304 tokens), server reached `Application startup complete`.
+- **`--enforce-eager` PP step time is roughly 160 ms.** Consistent with the
+  c=1 decode collapse above — enforce-eager disables CUDA-graph capture,
+  which on TP4 hides much of the per-step latency; PP4 pays it directly.
+- **Prefill favors PP4 over TP4 at this partition.** Uncached prefill on a
+  ~2,900-token prompt: **1,053 tok/s on PP4 vs 818 tok/s on TP4**, same
+  checkpoint, same box, same day.
+
+## 4. Speculative decoding on a communication-bound box
+
+The compute-bound advice published elsewhere — Unsloth's B200 sweep for
+GLM-5.3-Flash MTP in llama.cpp found `n=2 > n=3 > n=5` and recommends
+stopping around k=2 (community-reported, not reproduced by this club) —
+may invert on this box (**inferred**; a draft-depth sweep is in progress,
+not yet concluded). The reasoning: on a compute-bound box, every extra
+verified token in a deeper draft costs real FLOPs that are not free. On
+this Gen1/no-P2P box, the per-step cost model from §2
+(`fixed + small·tokens`, community-reported shape) means the marginal cost
+of verifying a longer accepted run is small relative to the fixed per-step
+overhead — so a deeper draft that raises mean accepted length should pay
+for itself more easily here than on a compute-bound box. This is a
+hypothesis awaiting our own sweep, not a result; do not treat "deeper is
+better here" as measured until the sweep publishes numbers.
+
+**Acceptance is workload-dependent, not a single number.** The community
+PP8 source above reports roughly a 3x spread in single-stream decode
+between structured/code workloads (123 tok/s) and prose (37 tok/s) at the
+same k=7 DFlash2 configuration (community-reported). Every published
+throughput cell in this lane's future sweep tables names its workload
+(code / prose / json / math / counting, or equivalent) rather than
+reporting one aggregate number — a single "tok/s" figure without a named
+workload is not comparable across runs on this box.
+
+## 5. Quant formats on SM80
+
+**NVFP4 checkpoints run via Marlin W4A16 dequant on this card — the same
+execution class as AWQ W4A16, not native FP4 tensor-core math (measured /
+inferred).** SM80 has no native FP4 tensor cores (see
+[LESSONS.md §a](LESSONS.md#a-kernel-and-format-compatibility-on-sm80) for
+the full format-compatibility table); an NVFP4-stored checkpoint on this
+box dequantizes through the same Marlin W4A16 path used for AWQ, and
+should be expected to perform similarly to AWQ W4A16 rather than to a
+native-FP4 box. This is measured for the dequant-path mechanism (Marlin
+selects on compute capability, confirmed elsewhere in this repo) and
+inferred for the specific NVFP4-vs-AWQ performance parity claim — we have
+not run a controlled NVFP4-vs-AWQ A/B on the same checkpoint on this box
+to confirm the numbers land the same.
+
+**Keep AWQ for A100 transfer.** Where a recipe needs to run unchanged on
+both this club's CMP 170HX pool and an A100 box, prefer AWQ W4A16 over
+NVFP4: A100 is also SM80, so the same Marlin dequant argument applies
+there, and AWQ is the better-tested path on this club's own hardware today
+(see the [GLM-5.3-Flash run table](models/glm-5.3-flash.md#run-on-cmp-170hx)).
+
+## Attribution
+
+- [promisezackr/glm53-flash-170hx-pp8](https://github.com/promisezackr/glm53-flash-170hx-pp8),
+  commit `90ec72e9525e90be701e742c70a20c4154418307` — PP8 cost model
+  (§2), community PP8 + DFlash2 benchmark numbers (§2, §4). License:
+  Apache-2.0, derivative of vLLM. Config and code from that repository are
+  cited for comparison only in this document; nothing from it has been
+  vendored into this club's fork as of this page's publication. That
+  repository's own credits chain: [344303947/vllm170hx](https://github.com/344303947/vllm170hx)
+  (SM8x patch base) and [bayley/vllm-170hx-glm5](https://github.com/bayley)
+  (PP-on-170HX validation) — carried here for completeness, not verified
+  by this club.
+- Unsloth's B200 MTP depth-sweep guidance for GLM-5.3-Flash (§4):
+  community-reported, cited for the compute-bound comparison point only,
+  not reproduced on this club's hardware.
+- The GLM-5.3-Flash SM80 vLLM fork this club's own TP4/PP4 measurements
+  run on is `PixelML/sm80vllm` branch `glm53-sm80`; its own upstream lineage
+  is documented in [UPSTREAM-SM80-NOTES.md](UPSTREAM-SM80-NOTES.md).
+
+## See also
+
+- [LESSONS.md §c](LESSONS.md#c-topology-pipeline-parallel-vs-tensor-parallel) —
+  per-checkpoint PP vs TP findings (DeepSeek-V4-Flash-0731, layer-partition
+  skew, `gpu-memory-utilization` thresholds for that checkpoint).
+- [HARDWARE.md — PCIe link status](HARDWARE.md#pcie-link-status) — the
+  original link-width measurement this page's §1 builds on.
+- [CLUSTER.md](CLUSTER.md) — topology guidance when scaling past one node.
+- [models/glm-5.3-flash.md](models/glm-5.3-flash.md) — the full GLM-5.3-Flash
+  run table and reproduce steps.


### PR DESCRIPTION
## Summary

- New page `docs/TOPOLOGY-AND-PARALLELISM.md`: what the PCIe link on CMP 170HX actually is (Gen1 x16 by design, x8 bifurcated-slot ceiling, no P2P under VFIO), why pipeline parallel beats tensor parallel here, PP4 boot facts, speculative-decoding-on-a-comm-bound-box reasoning, and NVFP4/AWQ quant-format notes on SM80.
- Cross-linked from README.md, `docs/HARDWARE.md` (PCIe link status section), and `docs/LESSONS.md` §c (topology section, which keeps its per-checkpoint DeepSeek-V4-Flash-0731 findings and now points here for the mechanism).
- Added a new operator-lessons section 6 to `docs/OPERATOR-LESSONS.md`: diagnosing a card that drops off the bus under multimodal-encoder profiling (slot power vs. riser vs. card, the discriminating tests, the recovery ladder, and the text-only workaround flag).
- Every claim is labeled measured / inferred / community-reported / untested per AGENTS.md. Community numbers (PP8 cost model, PP8+DFlash2 benchmarks) are attributed to promisezackr/glm53-flash-170hx-pp8 (Apache-2.0, commit 90ec72e9525e90be701e742c70a20c4154418307) with its own upstream credits carried through, and to Unsloth's B200 MTP sweep, both cited for comparison only and not reproduced as our own measurements.
- No slot ids, PCI addresses, VM/container names, hostnames, or private IPs in this diff (public-boundary grep run on the full staged diff, clean).

## Test plan

- [ ] `git diff --cached --check` clean (ran, no output)
- [ ] Public-boundary grep for private IPs/hostnames/PCI addresses/VM-container names run on the diff (ran, no hits besides one pre-existing unrelated Docker image tag false positive)
- [ ] Reviewer spot-checks the PP4 vs TP4 numbers against the linked evidence and confirms the promisezackr attribution note is sufficient