### PR TITLE
rental: document the 2026-09-05 training/extraction run

### DIFF
--- a/scripts/rental/README.md
+++ b/scripts/rental/README.md
@@ -5,23 +5,54 @@ this club's GLM-5.3-Flash work on it. They exist because the club's own node has
 four cards: anything that needs eight, or that needs a healthy PCIe link, has to
 be rented.
 
-**Status: prepared, not yet executed.** Nothing here has produced a published
-measurement. No rental in this bundle has been run to completion, so every
-timing in the runbook is a projection from the four-card box, not a measured
-rental figure. Treat the whole directory as a plan with executable parts.
+**Status: the training/extraction purpose has been run to completion once**
+(2026-09-05/06, ~7.5h, ended under the $17 spend cap). The inference-measurement
+purpose (`run_queue.sh`, TP4/PP4/TP8 sweep) is still prepared but never run —
+every timing for that path remains a projection from the four-card box.
 
 Two purposes, added in that order, sharing the same launcher and gate helpers:
 
 | Purpose | Entry point | State |
 |---|---|---|
 | 8-card inference measurement (TP4 / PP4 / TP8 sweep) | `run_queue.sh` | prepared, never run |
-| Drafter training + PP4 hidden-state extraction | `run_training.sh`, `run_extraction.sh` | prepared, never run |
+| Drafter training + PP4 hidden-state extraction | `run_training.sh`, `run_extraction.sh` | **run once, completed** (see below) |
 
 The second purpose was added on 2026-09-05, after the four-card PP4 lane became
 the [recipe of record](../../docs/models/glm-5.3-flash.md). The inference queue
 is therefore aimed at what four cards cannot answer — TP8, an eight-stage
 pipeline, and the same recipe on a healthy link — rather than at re-measuring
 the recipe of record.
+
+## What actually happened (2026-09-05/06 rental)
+
+A six-run block_size × learning-rate drafter sweep (bs8/13/17 × lr 1.5e-4/3e-4,
+8000 steps each, on the reserved slice-B corpus window) plus a PP4 slice-C
+hidden-state extraction (~1M tokens) ran back-to-back on one rented box. Best
+result: bs8-lr15 (D=7), per-token acceptance 0.089 — consistent with a separate
+finding on the club's own boxes that this drafter is not depth-limited (deeper
+block sizes did not help and sometimes hurt). Full numbers and slice-C manifest
+stats are in `seanphan/pixelml#108` (private coordination issue, not this repo).
+
+Two things did not go as planned and changed how this bundle should be used
+next time:
+
+- **The launch script was not dry-run before renting.** The corpus-window
+  bootstrap needed a live patch mid-rental (twice — once for an overlap with an
+  already-used window, once for a collision with a window reserved by a
+  parallel run elsewhere), burning paid GPU-clock time on fixes a dry run
+  against a throwaway/local target would have caught for free. Dry-run the full
+  bootstrap path, including the corpus-window arguments, before the meter
+  starts.
+- **Exfiltrate results to a public HF dataset or GHCR tag, never `rsync`
+  straight from the rented instance to an internal VM.** A direct
+  instance→VM `rsync` of the full `/out` tree (including optimizer
+  checkpoints, ~21GB/run) measured only ~5-8 MB/s and would not have finished
+  before the deadline. Uploading the same data from the instance to a public HF
+  dataset repo ran at ~75 MB/s and finished in minutes; the VM then mirrored it
+  back down via `snapshot_download`. `data-image/pull_data_image.py` in this
+  directory is a daemon-less fallback for the same pattern using a GHCR image
+  tag instead of an HF dataset repo, for instances (like this one) that have no
+  local docker daemon.
 
 ## Files
 


### PR DESCRIPTION
## Summary
- Updates `scripts/rental/README.md` status from "prepared, never run" to reflect that the drafter training + PP4 extraction purpose has now been run once, to completion, under the $17 spend cap.
- Adds a "What actually happened" section: six-run block_size x lr sweep + slice-C extraction, best result bs8-lr15 (D=7) at 0.089 per-token acceptance. Full numbers/manifest stats live in the private `seanphan/pixelml#108` issue, not this repo.
- Documents two operational lessons: dry-run the bootstrap/corpus-window args before renting, and exfiltrate results via HF dataset or GHCR rather than rsync straight to an internal VM (measured ~5-8 MB/s vs ~75 MB/s).

No instance ids, offer ids, or hostnames included (public-boundary safe per AGENTS.md).

## Test plan
- [x] Diff reviewed for internal identifiers before push